### PR TITLE
Fixes missing Session errors, broken Docker build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ actix-rt = "2.10.0"
 actix-web = "4.8.0"
 env_logger = "0.11.4"
 serde = { version = "1.0.204", features = ["derive"] }
-bsky-sdk = "0.1.14"
+bsky-sdk = "0.1.16"
 ipld-core = "0.4.1"
 derive_more = { version = "1.0.0", features = ["full"] }
 tracing = "0.1.41"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN cargo build --release
 
 COPY src src
 
+# You have to make the timestamp newer for it to build
+RUN touch src/main.rs
+
 RUN cargo build --release
 
 FROM rust:slim

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,6 +1,7 @@
 use crate::error_code::{CustomError, CustomErrorType};
 use crate::CreateAccountRequest;
-use bsky_sdk::api::agent::Session;
+use bsky_sdk::api::agent::atp_agent::AtpSession;
+use bsky_sdk::api::agent::Configure;
 use bsky_sdk::api::app::bsky::actor::defs::Preferences;
 use bsky_sdk::api::com::atproto::identity::sign_plc_operation::InputData;
 use bsky_sdk::api::com::atproto::repo::list_missing_blobs::RecordBlob;
@@ -25,7 +26,7 @@ pub async fn login(
     pds: &str,
     username: &str,
     password: &str,
-) -> Result<Session, Box<dyn std::error::Error>> {
+) -> Result<AtpSession, Box<dyn std::error::Error>> {
     bsky_agent.configure_endpoint(pds.to_string());
     let result = bsky_agent.login(username, password).await?;
     Ok(result)

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,17 +7,15 @@ use crate::error_code::{CustomError, CustomErrorType};
 use actix_web::dev::Server;
 use actix_web::web::Json;
 use actix_web::{middleware, post, App, HttpResponse, HttpServer};
-use bsky_sdk::api::agent::Session;
+use bsky_sdk::api::agent::atp_agent::AtpSession;
+use bsky_sdk::api::agent::Configure;
 use bsky_sdk::api::types::string::Did;
 use bsky_sdk::BskyAgent;
 use dotenvy::dotenv;
 use ipld_core::cid::Cid;
 use serde::{Deserialize, Serialize};
-use aws_sdk_s3 as s3;
 use std::{env, io};
 use std::io::ErrorKind;
-use aws_config::SdkConfig;
-use aws_sdk_s3::operation::put_object::{PutObjectError, PutObjectOutput};
 
 pub mod agent;
 pub mod error_code;
@@ -511,7 +509,7 @@ async fn login_helper(
     pds_host: &str,
     username: &str,
     password: &str,
-) -> Result<Session, CustomError> {
+) -> Result<AtpSession, CustomError> {
     agent.configure_endpoint(pds_host.to_string());
     match agent.login(username, password).await {
         Ok(session) => {


### PR DESCRIPTION
I was having issues building because it couldn't find `bsky_sdk::api::agent::Session`; replacing that with `bsky_sdk::api::agent::atp_agent::AtpSession` solved it.

Additionally, when I built the Docker image, it was releasing the stub file used to pull in dependencies because that was newer than the files being copied to the container (see: https://github.com/rust-lang/cargo/issues/7181#issuecomment-515260460). I've added a line to touch `main.rs` so it successfully builds.