### PR TITLE
fix(gui): show applicable message when get missing blobs completes

### DIFF
--- a/pdsmigration-gui/src/screens/advanced_home.rs
+++ b/pdsmigration-gui/src/screens/advanced_home.rs
@@ -150,7 +150,7 @@ impl Screen for AdvancedHome {
                                 let cid_str = format!("{:?}\n", blob.cid);
                                 file.write_all(cid_str.as_bytes()).await.unwrap();
                             }
-                            tracing::info!("Deactivated account");
+                            tracing::info!("Found missing blobs");
                         }
                         Err(e) => {
                             let mut error_write = error.write().await;


### PR DESCRIPTION
prior message misled users into thinking their account was deactivated when they ran the "determine mising blobs" task fixes #62

Reference: #62

## Description

Provides user a relevant message when the "determine missing blobs" task completes

## Related Issues

Fixes #62 

## Testing

Run the "determine missing blobs" task and observe log

## Affected Packages

<!-- Mark all packages affected by this change -->

- [ ] `pdsmigration-common` - Core library with migration logic
- [x] `pdsmigration-gui` - Desktop GUI application (egui/eframe)
- [ ] `pdsmigration-web` - Web service (Actix-Web + AWS S3)
- [ ] Project configuration (Cargo.toml, CI/CD, Docker, etc.)

## Type of Change

<!-- Mark relevant options with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements