### PR TITLE
Share a single job manager state among workers

### DIFF
--- a/pdsmigration-web/src/api/jobs.rs
+++ b/pdsmigration-web/src/api/jobs.rs
@@ -117,7 +117,12 @@ pub async fn get_job_api(
 
     match jobs.get(id).await {
         Some(job) => {
-            tracing::info!("Job found - ID: {}, status: {:?}, kind: {:?}", id, job.status, job.kind);
+            tracing::info!(
+                "Job found - ID: {}, status: {:?}, kind: {:?}",
+                id,
+                job.status,
+                job.kind
+            );
             Ok(HttpResponse::Ok().json(job))
         }
         None => {

--- a/pdsmigration-web/src/api/jobs.rs
+++ b/pdsmigration-web/src/api/jobs.rs
@@ -113,8 +113,16 @@ pub async fn get_job_api(
     path: web::Path<(Uuid,)>,
 ) -> Result<HttpResponse, ApiError> {
     let id = path.into_inner().0;
+    tracing::debug!("Fetching job with ID: {}", id);
+
     match jobs.get(id).await {
-        Some(job) => Ok(HttpResponse::Ok().json(job)),
-        None => Ok(HttpResponse::NotFound().finish()),
+        Some(job) => {
+            tracing::info!("Job found - ID: {}, status: {:?}, kind: {:?}", id, job.status, job.kind);
+            Ok(HttpResponse::Ok().json(job))
+        }
+        None => {
+            tracing::warn!("Job not found - ID: {}", id);
+            Ok(HttpResponse::NotFound().finish())
+        }
     }
 }

--- a/pdsmigration-web/src/main.rs
+++ b/pdsmigration-web/src/main.rs
@@ -44,6 +44,8 @@ fn init_http_server(app_config: AppConfig) -> io::Result<Server> {
         .endpoint("/metrics")
         .build()
         .expect("Failed to build prometheus metrics");
+    let job_manager = web::Data::new(JobManager::new());
+
     let server = HttpServer::new(move || {
         App::new()
             .wrap(prometheus.clone())
@@ -54,7 +56,7 @@ fn init_http_server(app_config: AppConfig) -> io::Result<Server> {
             ))
             .wrap(middleware::auth_token::AuthToken::new())
             .app_data(web::Data::new(app_config.clone()))
-            .app_data(web::Data::new(JobManager::new()))
+            .app_data(job_manager.clone())
             .app_data(web::JsonConfig::default().error_handler(|err, _req| {
                 let api_err = errors::ApiError::Validation {
                     field: "body".to_string(),


### PR DESCRIPTION
## Description

Job manager state may differ on deployments with more than 1 worker being used, as each owner would init its own job manager, potentially causing issues where a job ID is returning `200 OK` or `404 Not Found` depending on which worker attended the request.

## Related Issues

<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing

<!-- Describe the tests you ran to verify your changes -->

## Affected Packages

<!-- Mark all packages affected by this change -->

- [ ] `pdsmigration-common` - Core library with migration logic
- [ ] `pdsmigration-gui` - Desktop GUI application (egui/eframe)
- [x] `pdsmigration-web` - Web service (Actix-Web + AWS S3)
- [ ] Project configuration (Cargo.toml, CI/CD, Docker, etc.)

## Type of Change

<!-- Mark relevant options with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements