### PR TITLE
Job manager improvements (logs + shared state)

### DIFF
--- a/pdsmigration-web/src/api/jobs.rs
+++ b/pdsmigration-web/src/api/jobs.rs
@@ -113,6 +113,10 @@ pub async fn get_job_api(
     path: web::Path<(Uuid,)>,
 ) -> Result<HttpResponse, ApiError> {
     let id = path.into_inner().0;
+    let list = jobs.list().await;
+    let job_ids: Vec<String> = list.iter().map(|job| job.id.clone()).collect();
+    tracing::info!(request_guid = %id, job_ids = ?job_ids, "Getting job with ID: {}", id);
+
     match jobs.get(id).await {
         Some(job) => Ok(HttpResponse::Ok().json(job)),
         None => Ok(HttpResponse::NotFound().finish()),

--- a/pdsmigration-web/src/api/jobs.rs
+++ b/pdsmigration-web/src/api/jobs.rs
@@ -118,7 +118,18 @@ pub async fn get_job_api(
     tracing::info!(request_guid = %id, job_ids = ?job_ids, "Getting job with ID: {}", id);
 
     match jobs.get(id).await {
-        Some(job) => Ok(HttpResponse::Ok().json(job)),
+        Some(job) => {
+            if let Some(progress) = &job.progress {
+                tracing::info!(
+                    job_status = ?job.status,
+                    successful_blobs = progress.successful_blobs,
+                    invalid_blobs = progress.invalid_blobs,
+                    total = progress.total,
+                    "Job found, logging progress"
+                );
+            }
+            Ok(HttpResponse::Ok().json(job))
+        }
         None => Ok(HttpResponse::NotFound().finish()),
     }
 }

--- a/pdsmigration-web/src/background_jobs.rs
+++ b/pdsmigration-web/src/background_jobs.rs
@@ -203,7 +203,7 @@ impl Default for JobManager {
     }
 }
 
-#[tracing::instrument]
+#[tracing::instrument(skip(state))]
 async fn export_blobs_api_job(
     id: Uuid,
     state: Arc<RwLock<JobState>>,

--- a/pdsmigration-web/src/main.rs
+++ b/pdsmigration-web/src/main.rs
@@ -40,6 +40,7 @@ pub const APPLICATION_JSON: &str = "application/json";
 fn init_http_server(app_config: AppConfig) -> io::Result<Server> {
     let server_port = app_config.server.port;
     let worker_count = app_config.server.workers;
+    let job_manager = JobManager::new();
     let prometheus = PrometheusMetricsBuilder::new("api")
         .endpoint("/metrics")
         .build()
@@ -54,7 +55,7 @@ fn init_http_server(app_config: AppConfig) -> io::Result<Server> {
             ))
             .wrap(middleware::auth_token::AuthToken::new())
             .app_data(web::Data::new(app_config.clone()))
-            .app_data(web::Data::new(JobManager::new()))
+            .app_data(web::Data::new(job_manager.clone()))
             .app_data(web::JsonConfig::default().error_handler(|err, _req| {
                 let api_err = errors::ApiError::Validation {
                     field: "body".to_string(),

--- a/pdsmigration-web/tests/integration_tests.rs
+++ b/pdsmigration-web/tests/integration_tests.rs
@@ -1,13 +1,13 @@
 use actix_web::{http::StatusCode, test, web, App};
 use pdsmigration_web::{
     api::{
-        activate_account_api, create_account_api, deactivate_account_api, export_blobs_api,
-        export_pds_api, get_service_auth_api, health_check, import_pds_api, migrate_plc_api,
+        activate_account_api, cancel_job_api, create_account_api, deactivate_account_api,
+        enqueue_export_blobs_job_api, export_blobs_api, export_pds_api, get_job_api,
+        get_service_auth_api, health_check, import_pds_api, list_jobs_api, migrate_plc_api,
         migrate_preferences_api, missing_blobs_api, request_token_api, upload_blobs_api,
-        cancel_job_api, enqueue_export_blobs_job_api, get_job_api, list_jobs_api,
     },
-    config::{AppConfig, ExternalServices, ServerConfig},
     background_jobs::JobManager,
+    config::{AppConfig, ExternalServices, ServerConfig},
 };
 use serde_json::json;
 


### PR DESCRIPTION
## Description

Supersedes #80

- Removing verbose logging of job state on export api job
- Adding logs to GET job API to keep track of status and requests
- Ensure job manager state is global for backend workers
- New integration tests for job manager

From #80:
> Job manager state may differ on deployments with more than 1 worker being used, as each owner would init its own job manager, potentially causing issues where a job ID is returning 200 OK or 404 Not Found depending on which worker attended the request.

<!-- Provide a clear and concise description of the changes in this PR -->

## Related Issues

<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing

Added tests to the job manager API

<!-- Describe the tests you ran to verify your changes -->

## Affected Packages

<!-- Mark all packages affected by this change -->

- [ ] `pdsmigration-common` - Core library with migration logic
- [ ] `pdsmigration-gui` - Desktop GUI application (egui/eframe)
- [x] `pdsmigration-web` - Web service (Actix-Web + AWS S3)
- [ ] Project configuration (Cargo.toml, CI/CD, Docker, etc.)

## Type of Change

<!-- Mark relevant options with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Build/CI changes
- [x] Test improvements