### PR TITLE
Pass PDS error messages to client on create account

### DIFF
--- a/pdsmigration-common/src/agent/account.rs
+++ b/pdsmigration-common/src/agent/account.rs
@@ -1,7 +1,7 @@
 use crate::{
-    CreateAccountInput, CreateAccountInputData, CreateAccountRequest,
+    try_parse_error_response, CreateAccountInput, CreateAccountInputData, CreateAccountRequest,
     CreateAccountWithoutPDSRequest, DeactivatedAccountInput, DeactivatedAccountInputData,
-    MigrationError, CREATE_ACCOUNT_PATH, try_parse_error_response,
+    MigrationError, CREATE_ACCOUNT_PATH,
 };
 use bsky_sdk::BskyAgent;
 use ipld_core::ipld::Ipld;
@@ -53,10 +53,7 @@ pub async fn create_account(
             reqwest::StatusCode::BAD_REQUEST => {
                 let error_message = try_parse_error_response(output).await;
 
-                tracing::error!(
-                    "Failed to create account - Bad Request: {}",
-                    error_message
-                );
+                tracing::error!("Failed to create account - Bad Request: {}", error_message);
                 return Err(MigrationError::Upstream {
                     message: error_message,
                 });
@@ -123,10 +120,7 @@ pub async fn create_account_without_pds(
             reqwest::StatusCode::BAD_REQUEST => {
                 let error_message = try_parse_error_response(output).await;
 
-                tracing::error!(
-                    "Failed to create account - Bad Request: {}",
-                    error_message
-                );
+                tracing::error!("Failed to create account - Bad Request: {}", error_message);
                 return Err(MigrationError::Upstream {
                     message: error_message,
                 });

--- a/pdsmigration-common/src/agent/account.rs
+++ b/pdsmigration-common/src/agent/account.rs
@@ -1,7 +1,7 @@
 use crate::{
     CreateAccountInput, CreateAccountInputData, CreateAccountRequest,
     CreateAccountWithoutPDSRequest, DeactivatedAccountInput, DeactivatedAccountInputData,
-    MigrationError, CREATE_ACCOUNT_PATH,
+    MigrationError, CREATE_ACCOUNT_PATH, try_parse_error_response,
 };
 use bsky_sdk::BskyAgent;
 use ipld_core::ipld::Ipld;
@@ -49,6 +49,17 @@ pub async fn create_account(
         Ok(output) => match output.status() {
             reqwest::StatusCode::OK => {
                 tracing::info!("Successfully created account");
+            }
+            reqwest::StatusCode::BAD_REQUEST => {
+                let error_message = try_parse_error_response(output).await;
+
+                tracing::error!(
+                    "Failed to create account - Bad Request: {}",
+                    error_message
+                );
+                return Err(MigrationError::Upstream {
+                    message: error_message,
+                });
             }
             _ => {
                 let status = output.status();
@@ -108,6 +119,17 @@ pub async fn create_account_without_pds(
         Ok(output) => match output.status() {
             reqwest::StatusCode::OK => {
                 tracing::info!("Successfully created account");
+            }
+            reqwest::StatusCode::BAD_REQUEST => {
+                let error_message = try_parse_error_response(output).await;
+
+                tracing::error!(
+                    "Failed to create account - Bad Request: {}",
+                    error_message
+                );
+                return Err(MigrationError::Upstream {
+                    message: error_message,
+                });
             }
             _ => {
                 let status = output.status();

--- a/pdsmigration-common/src/errors.rs
+++ b/pdsmigration-common/src/errors.rs
@@ -51,12 +51,10 @@ mod tests {
 
         Mock::given(method("GET"))
             .and(path("/test"))
-            .respond_with(
-                ResponseTemplate::new(400).set_body_json(serde_json::json!({
-                    "error": "InvalidRequest",
-                    "message": "The request was invalid"
-                })),
-            )
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "error": "InvalidRequest",
+                "message": "The request was invalid"
+            })))
             .mount(&mock_server)
             .await;
 
@@ -78,11 +76,9 @@ mod tests {
 
         Mock::given(method("GET"))
             .and(path("/test"))
-            .respond_with(
-                ResponseTemplate::new(400).set_body_json(serde_json::json!({
-                    "message": "Something went wrong"
-                })),
-            )
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "message": "Something went wrong"
+            })))
             .mount(&mock_server)
             .await;
 
@@ -104,11 +100,9 @@ mod tests {
 
         Mock::given(method("GET"))
             .and(path("/test"))
-            .respond_with(
-                ResponseTemplate::new(400).set_body_json(serde_json::json!({
-                    "error": "ServerError"
-                })),
-            )
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "error": "ServerError"
+            })))
             .mount(&mock_server)
             .await;
 

--- a/pdsmigration-common/src/errors.rs
+++ b/pdsmigration-common/src/errors.rs
@@ -13,3 +13,208 @@ pub enum MigrationError {
     #[display("Rate limit reached. Please try again later.")]
     RateLimitReached,
 }
+
+pub async fn try_parse_error_response(response: reqwest::Response) -> String {
+    let response_text = response
+        .text()
+        .await
+        .unwrap_or_else(|_| "Unable to read response".to_string());
+
+    if let Ok(error_json) = serde_json::from_str::<serde_json::Value>(&response_text) {
+        format!(
+            "{}: {}",
+            error_json
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Unknown error"),
+            error_json
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("No message")
+        )
+    } else {
+        response_text
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::{
+        matchers::{method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
+
+    #[tokio::test]
+    async fn test_parse_error_response_with_valid_json() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/test"))
+            .respond_with(
+                ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                    "error": "InvalidRequest",
+                    "message": "The request was invalid"
+                })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{}/test", mock_server.uri()))
+            .send()
+            .await
+            .unwrap();
+
+        let result = try_parse_error_response(response).await;
+
+        assert_eq!(result, "InvalidRequest: The request was invalid");
+    }
+
+    #[tokio::test]
+    async fn test_parse_error_response_with_missing_error_field() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/test"))
+            .respond_with(
+                ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                    "message": "Something went wrong"
+                })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{}/test", mock_server.uri()))
+            .send()
+            .await
+            .unwrap();
+
+        let result = try_parse_error_response(response).await;
+
+        assert_eq!(result, "Unknown error: Something went wrong");
+    }
+
+    #[tokio::test]
+    async fn test_parse_error_response_with_missing_message_field() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/test"))
+            .respond_with(
+                ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                    "error": "ServerError"
+                })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{}/test", mock_server.uri()))
+            .send()
+            .await
+            .unwrap();
+
+        let result = try_parse_error_response(response).await;
+
+        assert_eq!(result, "ServerError: No message");
+    }
+
+    #[tokio::test]
+    async fn test_parse_error_response_with_missing_both_fields() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/test"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "status": "failure"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{}/test", mock_server.uri()))
+            .send()
+            .await
+            .unwrap();
+
+        let result = try_parse_error_response(response).await;
+
+        assert_eq!(result, "Unknown error: No message");
+    }
+
+    #[tokio::test]
+    async fn test_parse_error_response_with_plain_text() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/test"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("Internal Server Error"))
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{}/test", mock_server.uri()))
+            .send()
+            .await
+            .unwrap();
+
+        let result = try_parse_error_response(response).await;
+
+        assert_eq!(result, "Internal Server Error");
+    }
+
+    #[tokio::test]
+    async fn test_parse_error_response_with_invalid_json() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/test"))
+            .respond_with(
+                ResponseTemplate::new(400)
+                    .set_body_string("{invalid json content}")
+                    .insert_header("content-type", "application/json"),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{}/test", mock_server.uri()))
+            .send()
+            .await
+            .unwrap();
+
+        let result = try_parse_error_response(response).await;
+
+        assert_eq!(result, "{invalid json content}");
+    }
+
+    #[tokio::test]
+    async fn test_parse_error_response_with_empty_body() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/test"))
+            .respond_with(ResponseTemplate::new(400).set_body_string(""))
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{}/test", mock_server.uri()))
+            .send()
+            .await
+            .unwrap();
+
+        let result = try_parse_error_response(response).await;
+
+        assert_eq!(result, "");
+    }
+}


### PR DESCRIPTION
## Description

When the PDS returns a non-200 status during create account, bubble up the error message instead of returning a generic Runtime error.

## Related Issues

<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing

New unit tests added.

## Affected Packages

<!-- Mark all packages affected by this change -->

- [x] `pdsmigration-common` - Core library with migration logic
- [ ] `pdsmigration-gui` - Desktop GUI application (egui/eframe)
- [ ] `pdsmigration-web` - Web service (Actix-Web + AWS S3)
- [ ] Project configuration (Cargo.toml, CI/CD, Docker, etc.)

## Type of Change

<!-- Mark relevant options with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [x] Test improvements