### PR TITLE
Background job to upload blobs

### DIFF
--- a/pdsmigration-web/Cargo.toml
+++ b/pdsmigration-web/Cargo.toml
@@ -21,6 +21,7 @@ flate2 = { workspace = true }
 dotenvy = "0.15.7"
 actix-rt = "2.10.0"
 actix-web = "4.8.0"
+bsky-sdk = "0.1.21"
 tracing-actix-web = "0.7.19"
 pdsmigration-common = { workspace = true }
 tracing = "0.1.41"

--- a/pdsmigration-web/src/api/jobs.rs
+++ b/pdsmigration-web/src/api/jobs.rs
@@ -1,9 +1,9 @@
-use crate::api::ExportBlobsApiRequest;
+use crate::api::{ExportBlobsApiRequest, UploadBlobsApiRequest};
 use crate::background_jobs::{JobManager, JobRecord};
 use crate::errors::{ApiError, ApiErrorBody};
 use crate::{post, Json};
 use actix_web::{get, web, HttpResponse};
-use pdsmigration_common::ExportBlobsRequest;
+use pdsmigration_common::{ExportBlobsRequest, UploadBlobsRequest};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -34,6 +34,32 @@ pub async fn enqueue_export_blobs_job_api(
 ) -> Result<HttpResponse, ApiError> {
     let id = jobs
         .spawn_export_blobs(ExportBlobsRequest::from(req.into_inner()))
+        .await?;
+    Ok(HttpResponse::Accepted().json(EnqueueJobResponse {
+        job_id: id.to_string(),
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/jobs/upload-blobs",
+    request_body = UploadBlobsApiRequest,
+    responses(
+        (status = 202, description = "Job enqueued", body = EnqueueJobResponse, content_type = "application/json"),
+        (status = 400, description = "Invalid request", body = ApiErrorBody, content_type = "application/json"),
+        (status = 401, description = "Authentication error", body = ApiErrorBody, content_type = "application/json"),
+        (status = 429, description = "Rate limit exceeded", body = ApiErrorBody, content_type = "application/json"),
+    ),
+    tag = "pdsmigration-web"
+)]
+#[tracing::instrument(skip(jobs, req))]
+#[post("/jobs/upload-blobs")]
+pub async fn enqueue_upload_blobs_job_api(
+    jobs: web::Data<JobManager>,
+    req: Json<UploadBlobsApiRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let id = jobs
+        .spawn_upload_blobs(UploadBlobsRequest::from(req.into_inner()))
         .await?;
     Ok(HttpResponse::Accepted().json(EnqueueJobResponse {
         job_id: id.to_string(),

--- a/pdsmigration-web/src/background_jobs.rs
+++ b/pdsmigration-web/src/background_jobs.rs
@@ -1,8 +1,9 @@
 use crate::errors::ApiError;
+use bsky_sdk::api::agent::Configure;
 use futures_util::StreamExt;
 use pdsmigration_common::{
-    build_agent, download_blob, login_helper, missing_blobs, ExportBlobsRequest, GetBlobRequest,
-    MigrationError,
+    build_agent, download_blob, login_helper, missing_blobs, upload_blob, ExportBlobsRequest,
+    GetBlobRequest, MigrationError, UploadBlobsRequest,
 };
 use serde::{Deserialize, Serialize};
 #[allow(unused_imports)] // Used in schema attribute macros
@@ -28,6 +29,7 @@ fn now_millis() -> u64 {
 #[serde(rename_all = "snake_case")]
 pub enum JobKind {
     ExportBlobs,
+    UploadBlobs,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
@@ -128,6 +130,72 @@ impl JobManager {
         } else {
             false
         }
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn spawn_upload_blobs(&self, request: UploadBlobsRequest) -> Result<Uuid, ApiError> {
+        let id = Uuid::new_v4();
+        let rec = JobRecord {
+            id: id.to_string(),
+            kind: JobKind::UploadBlobs,
+            status: JobStatus::Queued,
+            error: None,
+            created_at: now_millis(),
+            started_at: None,
+            finished_at: None,
+            progress: Some(JobProgress {
+                successful_blobs: 0,
+                successful_blobs_ids: vec![],
+                invalid_blobs: 0,
+                invalid_blob_ids: vec![],
+                total: None,
+            }),
+        };
+
+        {
+            let mut st = self.state.write().await;
+            st.records.insert(id, rec);
+        }
+
+        let state = self.state.clone();
+        let handle = tokio::spawn(async move {
+            {
+                let mut st = state.write().await;
+                if let Some(r) = st.records.get_mut(&id) {
+                    r.status = JobStatus::Running;
+                    r.started_at = Some(now_millis());
+                }
+            }
+
+            let result = upload_blobs_api_job(id, state.clone(), request).await;
+
+            match result {
+                Ok(_) => {
+                    let mut st = state.write().await;
+                    if let Some(r) = st.records.get_mut(&id) {
+                        r.status = JobStatus::Success;
+                        r.finished_at = Some(now_millis());
+                    }
+                    st.running.remove(&id);
+                }
+                Err(e) => {
+                    let mut st = state.write().await;
+                    if let Some(r) = st.records.get_mut(&id) {
+                        r.status = JobStatus::Error;
+                        r.error = Some(format!("{}", e));
+                        r.finished_at = Some(now_millis());
+                    }
+                    st.running.remove(&id);
+                }
+            }
+        });
+
+        {
+            let mut st = self.state.write().await;
+            st.running.insert(id, RunningJob { handle });
+        }
+
+        Ok(id)
     }
 
     #[tracing::instrument(skip(self))]
@@ -353,5 +421,81 @@ async fn export_blobs_api_job(
             }
         }
     }
+    Ok(())
+}
+
+#[tracing::instrument(skip(state))]
+async fn upload_blobs_api_job(
+    id: Uuid,
+    state: Arc<RwLock<JobState>>,
+    req: UploadBlobsRequest,
+) -> Result<(), MigrationError> {
+    let agent = build_agent().await?;
+    agent.configure_endpoint(req.pds_host.clone());
+    let session = login_helper(
+        &agent,
+        req.pds_host.as_str(),
+        req.did.as_str(),
+        req.token.as_str(),
+    )
+    .await?;
+
+    let mut blob_dir;
+    let mut path = std::env::current_dir().unwrap();
+    path.push(session.did.as_str().replace(":", "-"));
+    match tokio::fs::read_dir(path.as_path()).await {
+        Ok(output) => blob_dir = output,
+        Err(error) => {
+            tracing::error!("{}", error.to_string());
+            return Err(MigrationError::Runtime {
+                message: "Failed to read blob directory".to_string(),
+            });
+        }
+    }
+
+    let mut file_count = 0u64;
+    while let Ok(Some(_)) = blob_dir.next_entry().await {
+        file_count += 1;
+    }
+    {
+        let mut st = state.write().await;
+        if let Some(r) = st.records.get_mut(&id) {
+            if let Some(progress) = r.progress.as_mut() {
+                progress.total = Some(file_count);
+            }
+        }
+    }
+
+    while let Some(blob) = blob_dir.next_entry().await.map_err(|error| {
+        tracing::error!("{}", error.to_string());
+        MigrationError::Runtime {
+            message: "Failed to get next blob".to_string(),
+        }
+    })? {
+        let file = tokio::fs::read(blob.path()).await.map_err(|error| {
+            tracing::error!("{}", error.to_string());
+            MigrationError::Runtime {
+                message: "Failed to read next blob".to_string(),
+            }
+        })?;
+        let blob_cid_str = blob.file_name().to_string_lossy().to_string();
+        tracing::info!(
+            "Uploading blob: {:?} with size {}...",
+            blob_cid_str,
+            file.len()
+        );
+        upload_blob(&agent, file).await?;
+        {
+            let mut st = state.write().await;
+            if let Some(r) = st.records.get_mut(&id) {
+                if let Some(progress) = r.progress.as_mut() {
+                    progress.successful_blobs += 1;
+                    progress.successful_blobs_ids.push(blob_cid_str.clone());
+                }
+            }
+        }
+    }
+
+    tracing::info!("Finished uploading blobs for DID {}", session.did.as_str());
     Ok(())
 }

--- a/pdsmigration-web/src/background_jobs.rs
+++ b/pdsmigration-web/src/background_jobs.rs
@@ -477,13 +477,11 @@ async fn upload_blobs_api_job(
         );
         match upload_blob(&agent, file).await {
             Ok(_) => {
-                {
-                    let mut st = state.write().await;
-                    if let Some(r) = st.records.get_mut(&id) {
-                        if let Some(progress) = r.progress.as_mut() {
-                            progress.successful_blobs += 1;
-                            progress.successful_blobs_ids.push(blob_cid_str.clone());
-                        }
+                let mut st = state.write().await;
+                if let Some(r) = st.records.get_mut(&id) {
+                    if let Some(progress) = r.progress.as_mut() {
+                        progress.successful_blobs += 1;
+                        progress.successful_blobs_ids.push(blob_cid_str.clone());
                     }
                 }
             }
@@ -495,10 +493,7 @@ async fn upload_blobs_api_job(
                         tokio::time::sleep(five_minutes).await;
                     }
                     _ => {
-                        tracing::error!(
-                            "Unexpected error when uploading blob: {}",
-                            e.to_string()
-                        );
+                        tracing::error!("Unexpected error when uploading blob: {}", e.to_string());
                     }
                 }
                 tracing::error!("Failed to upload blob {}: {}", blob_cid_str, e);

--- a/pdsmigration-web/src/background_jobs.rs
+++ b/pdsmigration-web/src/background_jobs.rs
@@ -457,6 +457,9 @@ async fn upload_blobs_api_job(
     while let Ok(Some(_)) = blob_dir.next_entry().await {
         file_count += 1;
     }
+    // Initialize collections to track successful and failed blob IDs
+    let mut successful_blobs = Vec::new();
+    let mut invalid_blobs: Vec<String> = Vec::new();
     {
         let mut st = state.write().await;
         if let Some(r) = st.records.get_mut(&id) {
@@ -484,13 +487,30 @@ async fn upload_blobs_api_job(
             blob_cid_str,
             file.len()
         );
-        upload_blob(&agent, file).await?;
-        {
-            let mut st = state.write().await;
-            if let Some(r) = st.records.get_mut(&id) {
-                if let Some(progress) = r.progress.as_mut() {
-                    progress.successful_blobs += 1;
-                    progress.successful_blobs_ids.push(blob_cid_str.clone());
+        match upload_blob(&agent, file).await {
+            Ok(_) => {
+                successful_blobs.push(blob_cid_str.clone());
+                {
+                    let mut st = state.write().await;
+                    if let Some(r) = st.records.get_mut(&id) {
+                        if let Some(progress) = r.progress.as_mut() {
+                            progress.successful_blobs += 1;
+                            progress.successful_blobs_ids.push(blob_cid_str.clone());
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!("Failed to upload blob {}: {}", blob_cid_str, e);
+                invalid_blobs.push(blob_cid_str.clone());
+                {
+                    let mut st = state.write().await;
+                    if let Some(r) = st.records.get_mut(&id) {
+                        if let Some(progress) = r.progress.as_mut() {
+                            progress.invalid_blobs += 1;
+                            progress.invalid_blob_ids.push(blob_cid_str.clone());
+                        }
+                    }
                 }
             }
         }

--- a/pdsmigration-web/src/background_jobs.rs
+++ b/pdsmigration-web/src/background_jobs.rs
@@ -302,9 +302,6 @@ async fn export_blobs_api_job(
     )
     .await?;
 
-    // Initialize collections to track successful and failed blob IDs
-    let mut successful_blobs = Vec::new();
-    let mut invalid_blobs = Vec::new();
     let mut path = match std::env::current_dir() {
         Ok(path) => path,
         Err(e) => {
@@ -380,7 +377,6 @@ async fn export_blobs_api_job(
                     }
 
                     file.flush().await.unwrap();
-                    successful_blobs.push(blob_cid_str.clone());
 
                     {
                         let mut st = state.write().await;
@@ -407,7 +403,6 @@ async fn export_blobs_api_job(
                         }
                     }
                     tracing::error!("Failed to download missing blob with cid: {}", blob_cid_str);
-                    invalid_blobs.push(blob_cid_str.clone());
                     {
                         let mut st = state.write().await;
                         if let Some(r) = st.records.get_mut(&id) {
@@ -453,28 +448,21 @@ async fn upload_blobs_api_job(
         }
     }
 
-    let mut file_count = 0u64;
-    while let Ok(Some(_)) = blob_dir.next_entry().await {
-        file_count += 1;
+    let mut blobs_in_dir = Vec::new();
+    while let Ok(Some(entry)) = blob_dir.next_entry().await {
+        blobs_in_dir.push(entry);
     }
-    // Initialize collections to track successful and failed blob IDs
-    let mut successful_blobs = Vec::new();
-    let mut invalid_blobs: Vec<String> = Vec::new();
+
     {
         let mut st = state.write().await;
         if let Some(r) = st.records.get_mut(&id) {
             if let Some(progress) = r.progress.as_mut() {
-                progress.total = Some(file_count);
+                progress.total = Some(blobs_in_dir.len() as u64);
             }
         }
     }
 
-    while let Some(blob) = blob_dir.next_entry().await.map_err(|error| {
-        tracing::error!("{}", error.to_string());
-        MigrationError::Runtime {
-            message: "Failed to get next blob".to_string(),
-        }
-    })? {
+    for blob in blobs_in_dir {
         let file = tokio::fs::read(blob.path()).await.map_err(|error| {
             tracing::error!("{}", error.to_string());
             MigrationError::Runtime {
@@ -489,7 +477,6 @@ async fn upload_blobs_api_job(
         );
         match upload_blob(&agent, file).await {
             Ok(_) => {
-                successful_blobs.push(blob_cid_str.clone());
                 {
                     let mut st = state.write().await;
                     if let Some(r) = st.records.get_mut(&id) {
@@ -501,8 +488,20 @@ async fn upload_blobs_api_job(
                 }
             }
             Err(e) => {
+                match e {
+                    MigrationError::RateLimitReached => {
+                        tracing::error!("Rate limit reached, waiting 5 minutes");
+                        let five_minutes = Duration::from_secs(300);
+                        tokio::time::sleep(five_minutes).await;
+                    }
+                    _ => {
+                        tracing::error!(
+                            "Unexpected error when uploading blob: {}",
+                            e.to_string()
+                        );
+                    }
+                }
                 tracing::error!("Failed to upload blob {}: {}", blob_cid_str, e);
-                invalid_blobs.push(blob_cid_str.clone());
                 {
                     let mut st = state.write().await;
                     if let Some(r) = st.records.get_mut(&id) {

--- a/pdsmigration-web/src/main.rs
+++ b/pdsmigration-web/src/main.rs
@@ -7,10 +7,10 @@ mod openapi;
 
 use crate::api::{
     activate_account_api, cancel_job_api, create_account_api, deactivate_account_api,
-    enqueue_export_blobs_job_api, export_blobs_api, export_pds_api, get_job_api,
-    get_service_auth_api, health_check, import_pds_api, list_jobs_api, long_health_check,
-    migrate_plc_api, migrate_preferences_api, missing_blobs_api, request_token_api,
-    upload_blobs_api,
+    enqueue_export_blobs_job_api, enqueue_upload_blobs_job_api, export_blobs_api, export_pds_api,
+    get_job_api, get_service_auth_api, health_check, import_pds_api, list_jobs_api,
+    long_health_check, migrate_plc_api, migrate_preferences_api, missing_blobs_api,
+    request_token_api, upload_blobs_api,
 };
 use crate::background_jobs::JobManager;
 use crate::config::AppConfig;
@@ -71,6 +71,7 @@ fn init_http_server(app_config: AppConfig) -> io::Result<Server> {
             .service(export_blobs_api)
             .service(upload_blobs_api)
             .service(enqueue_export_blobs_job_api)
+            .service(enqueue_upload_blobs_job_api)
             .service(list_jobs_api)
             .service(get_job_api)
             .service(cancel_job_api)

--- a/pdsmigration-web/src/openapi.rs
+++ b/pdsmigration-web/src/openapi.rs
@@ -21,6 +21,7 @@ use crate::api::*;
         migrate_plc_api,
         get_service_auth_api,
         enqueue_export_blobs_job_api,
+        enqueue_upload_blobs_job_api,
         list_jobs_api,
         get_job_api,
         cancel_job_api,

--- a/pdsmigration-web/tests/integration_tests.rs
+++ b/pdsmigration-web/tests/integration_tests.rs
@@ -2,9 +2,10 @@ use actix_web::{http::StatusCode, test, web, App};
 use pdsmigration_web::{
     api::{
         activate_account_api, cancel_job_api, create_account_api, deactivate_account_api,
-        enqueue_export_blobs_job_api, export_blobs_api, export_pds_api, get_job_api,
-        get_service_auth_api, health_check, import_pds_api, list_jobs_api, migrate_plc_api,
-        migrate_preferences_api, missing_blobs_api, request_token_api, upload_blobs_api,
+        enqueue_export_blobs_job_api, enqueue_upload_blobs_job_api, export_blobs_api,
+        export_pds_api, get_job_api, get_service_auth_api, health_check, import_pds_api,
+        list_jobs_api, migrate_plc_api, migrate_preferences_api, missing_blobs_api,
+        request_token_api, upload_blobs_api,
     },
     background_jobs::JobManager,
     config::{AppConfig, ExternalServices, ServerConfig},
@@ -646,6 +647,156 @@ mod integration_tests {
         let req = test::TestRequest::post()
             .uri("/jobs/export-blobs")
             .set_json(&export_request)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+
+        let body = test::read_body(resp).await;
+        let response: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let job_id = response["job_id"].as_str().unwrap();
+
+        let cancel_req = test::TestRequest::post()
+            .uri(&format!("/jobs/{}/cancel", job_id))
+            .to_request();
+
+        let cancel_resp = test::call_service(&app, cancel_req).await;
+        assert_eq!(cancel_resp.status(), StatusCode::OK);
+
+        let cancel_body = test::read_body(cancel_resp).await;
+        let cancel_response: serde_json::Value = serde_json::from_slice(&cancel_body).unwrap();
+        assert_eq!(cancel_response["success"], true);
+    }
+
+    #[actix_rt::test]
+    async fn test_enqueue_upload_blobs_job_missing_fields() {
+        let app_config = create_test_config();
+        let job_manager = web::Data::new(JobManager::new());
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(app_config))
+                .app_data(job_manager)
+                .service(enqueue_upload_blobs_job_api),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/jobs/upload-blobs")
+            .set_json(&json!({}))
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_rt::test]
+    async fn test_get_existing_upload_blobs_job() {
+        let app_config = create_test_config();
+        let job_manager = web::Data::new(JobManager::new());
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(app_config))
+                .app_data(job_manager.clone())
+                .service(enqueue_upload_blobs_job_api)
+                .service(get_job_api),
+        )
+        .await;
+
+        let upload_request = json!({
+            "pds_host": "https://destination.pds.host",
+            "did": "did:plc:test123456789",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.example.signature"
+        });
+
+        let req = test::TestRequest::post()
+            .uri("/jobs/upload-blobs")
+            .set_json(&upload_request)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+
+        let body = test::read_body(resp).await;
+        let response: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let job_id = response["job_id"].as_str().unwrap();
+
+        let get_req = test::TestRequest::get()
+            .uri(&format!("/jobs/{}", job_id))
+            .to_request();
+
+        let get_resp = test::call_service(&app, get_req).await;
+        assert_eq!(get_resp.status(), StatusCode::OK);
+
+        let job_body = test::read_body(get_resp).await;
+        let job: serde_json::Value = serde_json::from_slice(&job_body).unwrap();
+        assert_eq!(job["id"].as_str().unwrap(), job_id);
+    }
+
+    #[actix_rt::test]
+    async fn test_list_jobs_with_upload_blobs_jobs() {
+        let app_config = create_test_config();
+        let job_manager = web::Data::new(JobManager::new());
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(app_config))
+                .app_data(job_manager.clone())
+                .service(enqueue_upload_blobs_job_api)
+                .service(list_jobs_api),
+        )
+        .await;
+
+        for i in 0..2 {
+            let upload_request = json!({
+                "pds_host": format!("https://destination{}.pds.host", i),
+                "did": "did:plc:test123456789",
+                "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.example.signature"
+            });
+
+            let req = test::TestRequest::post()
+                .uri("/jobs/upload-blobs")
+                .set_json(&upload_request)
+                .to_request();
+
+            let resp = test::call_service(&app, req).await;
+            assert_eq!(resp.status(), StatusCode::ACCEPTED);
+        }
+
+        let list_req = test::TestRequest::get().uri("/jobs").to_request();
+
+        let list_resp = test::call_service(&app, list_req).await;
+        assert_eq!(list_resp.status(), StatusCode::OK);
+
+        let body = test::read_body(list_resp).await;
+        let jobs: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(jobs.len(), 2);
+    }
+
+    #[actix_rt::test]
+    async fn test_cancel_upload_blobs_job() {
+        let app_config = create_test_config();
+        let job_manager = web::Data::new(JobManager::new());
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(app_config))
+                .app_data(job_manager.clone())
+                .service(enqueue_upload_blobs_job_api)
+                .service(cancel_job_api),
+        )
+        .await;
+
+        let upload_request = json!({
+            "pds_host": "https://destination.pds.host",
+            "did": "did:plc:test123456789",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.example.signature"
+        });
+
+        let req = test::TestRequest::post()
+            .uri("/jobs/upload-blobs")
+            .set_json(&upload_request)
             .to_request();
 
         let resp = test::call_service(&app, req).await;


### PR DESCRIPTION
## Description

Implements a new job type and endpoint to handle upload blobs stage through a background job, so the front-end can poll as needed instead of holding the request open.

Logic is similar to the export blobs job.

## Related Issues

Issues uploading blobs after move to S3 object storage.

## Testing

Unit tests added. Changes don't replace existing endpoint, so can test with front-end integration.

## Affected Packages

<!-- Mark all packages affected by this change -->

- [ ] `pdsmigration-common` - Core library with migration logic
- [ ] `pdsmigration-gui` - Desktop GUI application (egui/eframe)
- [x] `pdsmigration-web` - Web service (Actix-Web + AWS S3)
- [ ] Project configuration (Cargo.toml, CI/CD, Docker, etc.)

## Type of Change

<!-- Mark relevant options with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements