### PR TITLE
Refactor calls to get blob and DID-related filenames/paths

### DIFF
--- a/pdsmigration-common/src/agent/repo.rs
+++ b/pdsmigration-common/src/agent/repo.rs
@@ -1,4 +1,4 @@
-use crate::{GetRepoRequest, MigrationError};
+use crate::{did_to_car_filename, GetRepoRequest, MigrationError};
 use bsky_sdk::api::types::string::Did;
 use bsky_sdk::BskyAgent;
 use ipld_core::ipld::Ipld;
@@ -111,7 +111,7 @@ pub async fn account_export(agent: &BskyAgent, did: &Did) -> Result<(), Migratio
         .await;
     match result {
         Ok(output) => {
-            tokio::fs::write(did.as_str().to_string().replace(":", "-") + ".car", output)
+            tokio::fs::write(did_to_car_filename(did), output)
                 .await
                 .map_err(|error| {
                     tracing::error!("[{}] Failed write repo bytes to file: {:?}", did_str, error);

--- a/pdsmigration-common/src/export_all_blobs.rs
+++ b/pdsmigration-common/src/export_all_blobs.rs
@@ -1,5 +1,5 @@
 use crate::agent::{download_blob, list_all_blobs, login_helper};
-use crate::{build_agent, did_to_dirname, format_cid, MigrationError};
+use crate::{build_agent, did_blobs_path, format_cid, MigrationError};
 use bsky_sdk::api::types::string::Did;
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -63,8 +63,7 @@ pub async fn export_all_blobs_api(
     let did = session.did.as_str();
     tracing::info!("[{}] Starting export of all blobs from {}", did, req.origin);
     let blobs = list_all_blobs(&agent).await?;
-    let mut path = std::env::current_dir().unwrap();
-    path.push(did_to_dirname(did));
+    let path = did_blobs_path(did)?;
     match tokio::fs::create_dir(path.as_path()).await {
         Ok(_) => {}
         Err(e) => {
@@ -82,8 +81,7 @@ pub async fn export_all_blobs_api(
     for blob in &blobs {
         let session = agent.get_session().await.unwrap();
         let blob_cid_str = format_cid(blob);
-        let mut filepath = std::env::current_dir().unwrap();
-        filepath.push(did_to_dirname(&session.did));
+        let mut filepath = did_blobs_path(&session.did)?;
         filepath.push(&blob_cid_str);
         if !tokio::fs::try_exists(filepath).await.unwrap() {
             let get_blob_request = GetBlobRequest {
@@ -94,8 +92,7 @@ pub async fn export_all_blobs_api(
             match download_blob(agent.get_endpoint().await.as_str(), &get_blob_request).await {
                 Ok(mut stream) => {
                     tracing::info!("[{}] Successfully fetched missing blob", did);
-                    let mut path = std::env::current_dir().unwrap();
-                    path.push(did_to_dirname(&session.did));
+                    let mut path = did_blobs_path(&session.did)?;
                     path.push(&blob_cid_str);
                     let mut file = tokio::fs::File::create(path.as_path()).await.unwrap();
 

--- a/pdsmigration-common/src/export_all_blobs.rs
+++ b/pdsmigration-common/src/export_all_blobs.rs
@@ -1,5 +1,5 @@
 use crate::agent::{download_blob, list_all_blobs, login_helper};
-use crate::{build_agent, MigrationError};
+use crate::{build_agent, did_to_dirname, format_cid, MigrationError};
 use bsky_sdk::api::types::string::Did;
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -64,7 +64,7 @@ pub async fn export_all_blobs_api(
     tracing::info!("[{}] Starting export of all blobs from {}", did, req.origin);
     let blobs = list_all_blobs(&agent).await?;
     let mut path = std::env::current_dir().unwrap();
-    path.push(did.replace(":", "-"));
+    path.push(did_to_dirname(did));
     match tokio::fs::create_dir(path.as_path()).await {
         Ok(_) => {}
         Err(e) => {
@@ -81,38 +81,22 @@ pub async fn export_all_blobs_api(
     let mut failed_blobs = vec![];
     for blob in &blobs {
         let session = agent.get_session().await.unwrap();
+        let blob_cid_str = format_cid(blob);
         let mut filepath = std::env::current_dir().unwrap();
-        filepath.push(session.did.as_str().replace(":", "-"));
-        filepath.push(
-            format!("{blob:?}")
-                .strip_prefix("Cid(Cid(")
-                .unwrap()
-                .strip_suffix("))")
-                .unwrap(),
-        );
+        filepath.push(did_to_dirname(&session.did));
+        filepath.push(&blob_cid_str);
         if !tokio::fs::try_exists(filepath).await.unwrap() {
             let get_blob_request = GetBlobRequest {
                 did: session.did.clone(),
-                cid: format!("{blob:?}")
-                    .strip_prefix("Cid(Cid(")
-                    .unwrap()
-                    .strip_suffix("))")
-                    .unwrap()
-                    .to_string(),
+                cid: blob_cid_str.clone(),
                 token: session.access_jwt.clone(),
             };
             match download_blob(agent.get_endpoint().await.as_str(), &get_blob_request).await {
                 Ok(mut stream) => {
                     tracing::info!("[{}] Successfully fetched missing blob", did);
                     let mut path = std::env::current_dir().unwrap();
-                    path.push(session.did.as_str().replace(":", "-"));
-                    path.push(
-                        format!("{blob:?}")
-                            .strip_prefix("Cid(Cid(")
-                            .unwrap()
-                            .strip_suffix("))")
-                            .unwrap(),
-                    );
+                    path.push(did_to_dirname(&session.did));
+                    path.push(&blob_cid_str);
                     let mut file = tokio::fs::File::create(path.as_path()).await.unwrap();
 
                     while let Some(chunk) = stream.next().await {

--- a/pdsmigration-common/src/export_blobs.rs
+++ b/pdsmigration-common/src/export_blobs.rs
@@ -1,6 +1,6 @@
 use crate::agent::{download_blob, login_helper, missing_blobs};
 use crate::export_all_blobs::GetBlobRequest;
-use crate::{build_agent, did_to_dirname, format_cid, MigrationError};
+use crate::{build_agent, did_blobs_path, format_cid, MigrationError};
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::io::ErrorKind;
@@ -61,15 +61,7 @@ pub async fn export_blobs_api(
     // Initialize collections to track successful and failed blob IDs
     let mut successful_blobs = Vec::new();
     let mut invalid_blobs = Vec::new();
-    let mut path = match std::env::current_dir() {
-        Ok(path) => path,
-        Err(e) => {
-            return Err(MigrationError::Runtime {
-                message: e.to_string(),
-            })
-        }
-    };
-    path.push(did_to_dirname(did));
+    let path = did_blobs_path(did)?;
 
     if req.is_missing_blob_request {
         if let Err(e) = tokio::fs::remove_dir_all(path.as_path()).await {
@@ -104,15 +96,7 @@ pub async fn export_blobs_api(
                 });
             }
         };
-        let mut filepath = match std::env::current_dir() {
-            Ok(res) => res,
-            Err(e) => {
-                return Err(MigrationError::Runtime {
-                    message: e.to_string(),
-                });
-            }
-        };
-        filepath.push(did_to_dirname(&session.did));
+        let mut filepath = did_blobs_path(&session.did)?;
         filepath.push(
             missing_blob
                 .record_uri
@@ -131,8 +115,7 @@ pub async fn export_blobs_api(
             match download_blob(agent.get_endpoint().await.as_str(), &get_blob_request).await {
                 Ok(mut stream) => {
                     tracing::info!("[{}] Successfully fetched missing blob", did);
-                    let mut path = std::env::current_dir().unwrap();
-                    path.push(did_to_dirname(&session.did));
+                    let mut path = did_blobs_path(&session.did)?;
                     path.push(&blob_cid_str);
                     let mut file = tokio::fs::File::create(path.as_path()).await.unwrap();
 

--- a/pdsmigration-common/src/export_blobs.rs
+++ b/pdsmigration-common/src/export_blobs.rs
@@ -1,6 +1,6 @@
 use crate::agent::{download_blob, login_helper, missing_blobs};
 use crate::export_all_blobs::GetBlobRequest;
-use crate::{build_agent, MigrationError};
+use crate::{build_agent, did_to_dirname, format_cid, MigrationError};
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::io::ErrorKind;
@@ -69,7 +69,7 @@ pub async fn export_blobs_api(
             })
         }
     };
-    path.push(did.replace(":", "-"));
+    path.push(did_to_dirname(did));
 
     if req.is_missing_blob_request {
         if let Err(e) = tokio::fs::remove_dir_all(path.as_path()).await {
@@ -112,7 +112,7 @@ pub async fn export_blobs_api(
                 });
             }
         };
-        filepath.push(session.did.as_str().replace(":", "-"));
+        filepath.push(did_to_dirname(&session.did));
         filepath.push(
             missing_blob
                 .record_uri
@@ -122,13 +122,7 @@ pub async fn export_blobs_api(
                 .unwrap_or("fallback"),
         );
         if !tokio::fs::try_exists(&filepath).await.unwrap() {
-            let missing_blob_cid = missing_blob.cid.clone();
-            let blob_cid_str = format!("{missing_blob_cid:?}")
-                .strip_prefix("Cid(Cid(")
-                .unwrap()
-                .strip_suffix("))")
-                .unwrap()
-                .to_string();
+            let blob_cid_str = format_cid(&missing_blob.cid);
             let get_blob_request = GetBlobRequest {
                 did: session.did.clone(),
                 cid: blob_cid_str.clone(),
@@ -138,7 +132,7 @@ pub async fn export_blobs_api(
                 Ok(mut stream) => {
                     tracing::info!("[{}] Successfully fetched missing blob", did);
                     let mut path = std::env::current_dir().unwrap();
-                    path.push(session.did.as_str().replace(":", "-"));
+                    path.push(did_to_dirname(&session.did));
                     path.push(&blob_cid_str);
                     let mut file = tokio::fs::File::create(path.as_path()).await.unwrap();
 

--- a/pdsmigration-common/src/export_pds.rs
+++ b/pdsmigration-common/src/export_pds.rs
@@ -1,5 +1,5 @@
 use crate::agent::{download_repo, login_helper};
-use crate::{build_agent, GetRepoRequest, MigrationError};
+use crate::{build_agent, did_to_car_filename, GetRepoRequest, MigrationError};
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -45,7 +45,7 @@ pub async fn export_pds_api(req: ExportPDSRequest) -> Result<(), MigrationError>
                     message: "Failed to get current directory".to_string(),
                 }
             })?;
-            path.push(session.did.clone().replace(":", "-") + ".car");
+            path.push(did_to_car_filename(&session.did));
 
             let mut file = tokio::fs::File::create(path.as_path())
                 .await

--- a/pdsmigration-common/src/import_pds.rs
+++ b/pdsmigration-common/src/import_pds.rs
@@ -1,5 +1,5 @@
 use crate::agent::{account_import, login_helper};
-use crate::{build_agent, MigrationError};
+use crate::{build_agent, did_to_car_filename, MigrationError};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -21,7 +21,7 @@ pub async fn import_pds_api(req: ImportPDSRequest) -> Result<(), MigrationError>
         req.token.as_str(),
     )
     .await?;
-    let filename = session.did.as_str().to_string().replace(":", "-") + ".car";
+    let filename = did_to_car_filename(&session.did);
     tracing::info!("[{}] Importing repo from {}", did, filename);
     account_import(&agent, filename.as_str()).await?;
     tracing::info!("[{}] Successfully imported PDS", did);

--- a/pdsmigration-common/src/lib.rs
+++ b/pdsmigration-common/src/lib.rs
@@ -72,3 +72,93 @@ pub fn public_key_to_did_key(public_key: PublicKey) -> String {
     let public_key_str = format!("did:key:{pk_multibase}");
     public_key_str
 }
+
+/// Convert a DID into the directory / file basename used on disk.
+pub fn did_to_dirname<D: AsRef<str>>(did: D) -> String {
+    did.as_ref().replace(':', "-")
+}
+
+/// Convert a DID into a canonical CAR filename for repository
+/// exports / imports (`<did-with-colons-replaced>.car`).
+pub fn did_to_car_filename<D: AsRef<str>>(did: D) -> String {
+    let mut name = did_to_dirname(did);
+    name.push_str(".car");
+    name
+}
+
+/// Normalize a CID representation Cid(Cid(<inner>)) into
+/// its inner ID as a string.
+pub fn format_cid<T: std::fmt::Debug>(cid: &T) -> String {
+    let raw = format!("{cid:?}");
+    raw.strip_prefix("Cid(Cid(")
+        .and_then(|s| s.strip_suffix("))"))
+        .map(str::to_string)
+        .unwrap_or(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bsky_sdk::api::types::string::{Cid, Did};
+    use std::str::FromStr;
+
+    #[test]
+    fn dirname_replaces_colons() {
+        assert_eq!(
+            did_to_dirname("did:plc:abc123"),
+            "did-plc-abc123".to_string()
+        );
+    }
+
+    #[test]
+    fn dirname_accepts_did_type() {
+        let did = Did::new("did:plc:abc123".to_string()).expect("valid test DID");
+        assert_eq!(did_to_dirname(&did), "did-plc-abc123".to_string());
+    }
+
+    #[test]
+    fn dirname_passthrough_when_no_colon() {
+        assert_eq!(did_to_dirname("plain"), "plain".to_string());
+    }
+
+    #[test]
+    fn dirname_handles_empty_string() {
+        assert_eq!(did_to_dirname(""), "".to_string());
+    }
+
+    #[test]
+    fn car_filename_appends_extension() {
+        assert_eq!(
+            did_to_car_filename("did:plc:abc123"),
+            "did-plc-abc123.car".to_string()
+        );
+    }
+
+    #[test]
+    fn car_filename_for_web_did() {
+        assert_eq!(
+            did_to_car_filename("did:web:example.com"),
+            "did-web-example.com.car".to_string()
+        );
+    }
+
+    #[test]
+    fn car_filename_accepts_did_type() {
+        let did = Did::new("did:plc:abc123".to_string()).expect("valid test DID");
+        assert_eq!(did_to_car_filename(&did), "did-plc-abc123.car".to_string());
+    }
+
+    #[test]
+    fn format_cid_strips_double_wrapping() {
+        let raw = "bafyreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy";
+        let cid = Cid::from_str(raw).expect("valid test CID");
+        assert_eq!(format!("{cid:?}"), format!("Cid(Cid({raw}))"));
+        assert_eq!(format_cid(&cid), raw.to_string());
+    }
+
+    #[test]
+    fn format_cid_returns_raw_when_unwrapping_fails() {
+        let value = "not-a-cid";
+        assert_eq!(format_cid(&value), format!("{value:?}"));
+    }
+}

--- a/pdsmigration-common/src/lib.rs
+++ b/pdsmigration-common/src/lib.rs
@@ -73,11 +73,6 @@ pub fn public_key_to_did_key(public_key: PublicKey) -> String {
     public_key_str
 }
 
-/// Convert a DID into the directory / file basename used on disk.
-pub fn did_to_dirname<D: AsRef<str>>(did: D) -> String {
-    did.as_ref().replace(':', "-")
-}
-
 /// Convert a DID into a canonical CAR filename for repository
 /// exports / imports (`<did-with-colons-replaced>.car`).
 pub fn did_to_car_filename<D: AsRef<str>>(did: D) -> String {
@@ -94,6 +89,21 @@ pub fn format_cid<T: std::fmt::Debug>(cid: &T) -> String {
         .and_then(|s| s.strip_suffix("))"))
         .map(str::to_string)
         .unwrap_or(raw)
+}
+
+/// Build the canonical on-disk directory path for a DID's blobs:
+/// `<current_dir>/<did-with-colons-replaced>`.
+pub fn did_blobs_path<D: AsRef<str>>(did: D) -> Result<std::path::PathBuf, MigrationError> {
+    let mut path = std::env::current_dir().map_err(|e| MigrationError::Runtime {
+        message: e.to_string(),
+    })?;
+    path.push(did_to_dirname(did));
+    Ok(path)
+}
+
+/// Convert a DID into the directory / file basename used on disk.
+fn did_to_dirname<D: AsRef<str>>(did: D) -> String {
+    did.as_ref().replace(':', "-")
 }
 
 #[cfg(test)]
@@ -160,5 +170,20 @@ mod tests {
     fn format_cid_returns_raw_when_unwrapping_fails() {
         let value = "not-a-cid";
         assert_eq!(format_cid(&value), format!("{value:?}"));
+    }
+
+    #[test]
+    fn did_blob_dir_appends_dirname_to_cwd() {
+        let cwd = std::env::current_dir().expect("cwd should be readable in tests");
+        let path = did_blobs_path("did:plc:abc123").expect("cwd should be readable in tests");
+        assert_eq!(path, cwd.join("did-plc-abc123"));
+    }
+
+    #[test]
+    fn did_blob_dir_accepts_did_type() {
+        let cwd = std::env::current_dir().expect("cwd should be readable in tests");
+        let did = Did::new("did:plc:abc123".to_string()).expect("valid test DID");
+        let path = did_blobs_path(&did).expect("cwd should be readable in tests");
+        assert_eq!(path, cwd.join("did-plc-abc123"));
     }
 }

--- a/pdsmigration-common/src/upload_blobs.rs
+++ b/pdsmigration-common/src/upload_blobs.rs
@@ -1,5 +1,5 @@
 use crate::agent::{login_helper, upload_blob};
-use crate::{build_agent, MigrationError};
+use crate::{build_agent, did_to_dirname, MigrationError};
 use bsky_sdk::api::agent::Configure;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -36,7 +36,7 @@ pub async fn upload_blobs_api(req: UploadBlobsRequest) -> Result<(), MigrationEr
     let did = session.did.as_str();
     let mut blob_dir;
     let mut path = std::env::current_dir().unwrap();
-    path.push(did.replace(":", "-"));
+    path.push(did_to_dirname(did));
     match tokio::fs::read_dir(path.as_path()).await {
         Ok(output) => blob_dir = output,
         Err(error) => {

--- a/pdsmigration-common/src/upload_blobs.rs
+++ b/pdsmigration-common/src/upload_blobs.rs
@@ -1,5 +1,5 @@
 use crate::agent::{login_helper, upload_blob};
-use crate::{build_agent, did_to_dirname, MigrationError};
+use crate::{build_agent, did_blobs_path, MigrationError};
 use bsky_sdk::api::agent::Configure;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -35,8 +35,7 @@ pub async fn upload_blobs_api(req: UploadBlobsRequest) -> Result<(), MigrationEr
 
     let did = session.did.as_str();
     let mut blob_dir;
-    let mut path = std::env::current_dir().unwrap();
-    path.push(did_to_dirname(did));
+    let path = did_blobs_path(did)?;
     match tokio::fs::read_dir(path.as_path()).await {
         Ok(output) => blob_dir = output,
         Err(error) => {

--- a/pdsmigration-web/src/api/export_repo.rs
+++ b/pdsmigration-web/src/api/export_repo.rs
@@ -2,7 +2,7 @@ use crate::errors::{ApiError, ApiErrorBody};
 use crate::post;
 use actix_web::web::Json;
 use actix_web::HttpResponse;
-use pdsmigration_common::ExportPDSRequest;
+use pdsmigration_common::{did_to_car_filename, ExportPDSRequest};
 use serde::{Deserialize, Serialize};
 use std::env;
 use utoipa::ToSchema;
@@ -79,8 +79,8 @@ pub async fn export_pds_api(req: Json<ExportPDSApiRequest>) -> Result<HttpRespon
     let client = aws_sdk_s3::Client::new(&config);
 
     let bucket_name = "migration".to_string();
-    let file_name = did.replace(":", "-") + ".car";
-    let key = "migration/".to_string() + &did.replace(":", "-") + ".car";
+    let file_name = did_to_car_filename(&did);
+    let key = format!("migration/{file_name}");
 
     tracing::debug!(
         "[{}] Uploading file {} to S3 bucket {} with key {}",

--- a/pdsmigration-web/src/api/import_repo.rs
+++ b/pdsmigration-web/src/api/import_repo.rs
@@ -3,7 +3,7 @@ use crate::errors::{ApiError, ApiErrorBody};
 use crate::post;
 use actix_web::web::{Data, Json};
 use actix_web::HttpResponse;
-use pdsmigration_common::ImportPDSRequest;
+use pdsmigration_common::{did_to_car_filename, ImportPDSRequest};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -57,8 +57,8 @@ pub async fn import_pds_api(
     let client = aws_sdk_s3::Client::new(&config);
 
     let bucket_name = "migration".to_string();
-    let file_name = did.replace(":", "-") + ".car";
-    let key = "migration/".to_string() + &did.replace(":", "-") + ".car";
+    let file_name = did_to_car_filename(&did);
+    let key = format!("migration/{file_name}");
 
     // Download the file from S3
     let s3_response = client

--- a/pdsmigration-web/src/background_jobs.rs
+++ b/pdsmigration-web/src/background_jobs.rs
@@ -3,8 +3,8 @@ use bsky_sdk::api::agent::Configure;
 use derive_more::Display;
 use futures_util::StreamExt;
 use pdsmigration_common::{
-    build_agent, download_blob, login_helper, missing_blobs, upload_blob_v2, ExportBlobsRequest,
-    GetBlobRequest, MigrationError, UploadBlobsRequest,
+    build_agent, did_to_dirname, download_blob, format_cid, login_helper, missing_blobs,
+    upload_blob_v2, ExportBlobsRequest, GetBlobRequest, MigrationError, UploadBlobsRequest,
 };
 use serde::{Deserialize, Serialize};
 #[allow(unused_imports)] // Used in schema attribute macros
@@ -320,7 +320,7 @@ async fn export_blobs_api_job(
             })
         }
     };
-    path.push(session.did.as_str().replace(":", "-"));
+    path.push(did_to_dirname(&session.did));
     let did = session.did.as_str();
     if req.is_missing_blob_request {
         if let Err(e) = tokio::fs::remove_dir_all(path.as_path()).await {
@@ -362,7 +362,7 @@ async fn export_blobs_api_job(
                 });
             }
         };
-        filepath.push(session.did.as_str().replace(":", "-"));
+        filepath.push(did_to_dirname(&session.did));
         filepath.push(
             missing_blob
                 .record_uri
@@ -372,13 +372,7 @@ async fn export_blobs_api_job(
                 .unwrap_or("fallback"),
         );
         if !tokio::fs::try_exists(filepath).await.unwrap() {
-            let missing_blob_cid = missing_blob.cid.clone();
-            let blob_cid_str = format!("{missing_blob_cid:?}")
-                .strip_prefix("Cid(Cid(")
-                .unwrap()
-                .strip_suffix("))")
-                .unwrap()
-                .to_string();
+            let blob_cid_str = format_cid(&missing_blob.cid);
             let get_blob_request = GetBlobRequest {
                 did: session.did.clone(),
                 cid: blob_cid_str.clone(),
@@ -388,7 +382,7 @@ async fn export_blobs_api_job(
                 Ok(mut stream) => {
                     tracing::info!("[{}] Successfully fetched missing blob", did);
                     let mut path = std::env::current_dir().unwrap();
-                    path.push(session.did.as_str().replace(":", "-"));
+                    path.push(did_to_dirname(&session.did));
                     path.push(&blob_cid_str);
                     let mut file = tokio::fs::File::create(path.as_path()).await.unwrap();
 
@@ -437,7 +431,7 @@ async fn upload_blobs_api_job(
 
     let mut blob_dir;
     let mut path = std::env::current_dir().unwrap();
-    path.push(session.did.as_str().replace(":", "-"));
+    path.push(did_to_dirname(&session.did));
     match tokio::fs::read_dir(path.as_path()).await {
         Ok(output) => blob_dir = output,
         Err(error) => {

--- a/pdsmigration-web/src/background_jobs.rs
+++ b/pdsmigration-web/src/background_jobs.rs
@@ -3,7 +3,7 @@ use bsky_sdk::api::agent::Configure;
 use derive_more::Display;
 use futures_util::StreamExt;
 use pdsmigration_common::{
-    build_agent, did_to_dirname, download_blob, format_cid, login_helper, missing_blobs,
+    build_agent, did_blobs_path, download_blob, format_cid, login_helper, missing_blobs,
     upload_blob_v2, ExportBlobsRequest, GetBlobRequest, MigrationError, UploadBlobsRequest,
 };
 use serde::{Deserialize, Serialize};
@@ -312,15 +312,7 @@ async fn export_blobs_api_job(
     )
     .await?;
 
-    let mut path = match std::env::current_dir() {
-        Ok(path) => path,
-        Err(e) => {
-            return Err(MigrationError::Runtime {
-                message: e.to_string(),
-            })
-        }
-    };
-    path.push(did_to_dirname(&session.did));
+    let path = did_blobs_path(&session.did)?;
     let did = session.did.as_str();
     if req.is_missing_blob_request {
         if let Err(e) = tokio::fs::remove_dir_all(path.as_path()).await {
@@ -354,15 +346,7 @@ async fn export_blobs_api_job(
                 });
             }
         };
-        let mut filepath = match std::env::current_dir() {
-            Ok(res) => res,
-            Err(e) => {
-                return Err(MigrationError::Runtime {
-                    message: e.to_string(),
-                });
-            }
-        };
-        filepath.push(did_to_dirname(&session.did));
+        let mut filepath = did_blobs_path(&session.did)?;
         filepath.push(
             missing_blob
                 .record_uri
@@ -381,8 +365,7 @@ async fn export_blobs_api_job(
             match download_blob(agent.get_endpoint().await.as_str(), &get_blob_request).await {
                 Ok(mut stream) => {
                     tracing::info!("[{}] Successfully fetched missing blob", did);
-                    let mut path = std::env::current_dir().unwrap();
-                    path.push(did_to_dirname(&session.did));
+                    let mut path = did_blobs_path(&session.did)?;
                     path.push(&blob_cid_str);
                     let mut file = tokio::fs::File::create(path.as_path()).await.unwrap();
 
@@ -430,8 +413,7 @@ async fn upload_blobs_api_job(
     let did = session.did.as_str();
 
     let mut blob_dir;
-    let mut path = std::env::current_dir().unwrap();
-    path.push(did_to_dirname(&session.did));
+    let path = did_blobs_path(&session.did)?;
     match tokio::fs::read_dir(path.as_path()).await {
         Ok(output) => blob_dir = output,
         Err(error) => {


### PR DESCRIPTION
## Description

Minor refactor to centralize duplicate code that deals with DID and blob paths, directories and filenames, to standardize across the codebase. No behaviour change expected.

## Related Issues

<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing

Added unit tests to cover the refactore code.

## Affected Packages

<!-- Mark all packages affected by this change -->

- [x] `pdsmigration-common` - Core library with migration logic
- [ ] `pdsmigration-gui` - Desktop GUI application (egui/eframe)
- [x] `pdsmigration-web` - Web service (Actix-Web + AWS S3)
- [ ] Project configuration (Cargo.toml, CI/CD, Docker, etc.)

## Type of Change

<!-- Mark relevant options with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements