### PR TITLE
Fix mismatch directories on repo import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install --no-install-recommends -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
+WORKDIR /app
 COPY --from=builder /app/target/release/pdsmigration-web /app/
 
 ENTRYPOINT ["/app/pdsmigration-web"]

--- a/pdsmigration-common/src/export_pds.rs
+++ b/pdsmigration-common/src/export_pds.rs
@@ -1,7 +1,5 @@
 use crate::agent::{download_repo, login_helper};
-use crate::{
-    build_agent, did_to_car_filename, downloads_dir, GetRepoRequest, MigrationError, REDACTED,
-};
+use crate::{build_agent, repo_car_path, GetRepoRequest, MigrationError, REDACTED};
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -41,13 +39,12 @@ pub async fn export_pds_api(req: ExportPDSRequest) -> Result<(), MigrationError>
     };
     match download_repo(agent.get_endpoint().await.as_str(), &get_repo_request).await {
         Ok(mut stream) => {
-            let mut path = downloads_dir().map_err(|error| {
+            let path = repo_car_path(&session.did).map_err(|error| {
                 tracing::error!("[{}] Failed to resolve downloads directory: {}", did, error);
                 MigrationError::Runtime {
                     message: "Failed to resolve downloads directory".to_string(),
                 }
             })?;
-            path.push(did_to_car_filename(&session.did));
             tracing::info!(
                 "[{}] Writing account repo export to {}",
                 did,

--- a/pdsmigration-common/src/import_pds.rs
+++ b/pdsmigration-common/src/import_pds.rs
@@ -1,5 +1,5 @@
 use crate::agent::{account_import, login_helper};
-use crate::{build_agent, did_to_car_filename, MigrationError, REDACTED};
+use crate::{build_agent, did_to_car_filename, downloads_dir, MigrationError, REDACTED};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -33,8 +33,10 @@ pub async fn import_pds_api(req: ImportPDSRequest) -> Result<(), MigrationError>
     )
     .await?;
     let filename = did_to_car_filename(&session.did);
-    tracing::info!("[{}] Importing repo from {}", did, filename);
-    account_import(&agent, filename.as_str()).await?;
+    let path = downloads_dir()?.join(&filename);
+    let path_str = path.to_string_lossy().into_owned();
+    tracing::info!("[{}] Importing repo from {}", did, path_str);
+    account_import(&agent, path_str.as_str()).await?;
     tracing::info!("[{}] Successfully imported PDS", did);
     Ok(())
 }

--- a/pdsmigration-common/src/import_pds.rs
+++ b/pdsmigration-common/src/import_pds.rs
@@ -1,5 +1,5 @@
 use crate::agent::{account_import, login_helper};
-use crate::{build_agent, did_to_car_filename, downloads_dir, MigrationError, REDACTED};
+use crate::{build_agent, repo_car_path, MigrationError, REDACTED};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -32,8 +32,7 @@ pub async fn import_pds_api(req: ImportPDSRequest) -> Result<(), MigrationError>
         req.token.as_str(),
     )
     .await?;
-    let filename = did_to_car_filename(&session.did);
-    let path = downloads_dir()?.join(&filename);
+    let path = repo_car_path(&session.did)?;
     let path_str = path.to_string_lossy().into_owned();
     tracing::info!("[{}] Importing repo from {}", did, path_str);
     account_import(&agent, path_str.as_str()).await?;

--- a/pdsmigration-common/src/lib.rs
+++ b/pdsmigration-common/src/lib.rs
@@ -95,6 +95,14 @@ pub fn did_blobs_path<D: AsRef<str>>(did: D) -> Result<std::path::PathBuf, Migra
     Ok(path)
 }
 
+/// Build the canonical on-disk path for a DID's repo CAR export:
+/// `<downloads_dir>/<did-with-colons-replaced>.car`.
+pub fn repo_car_path<D: AsRef<str>>(did: D) -> Result<std::path::PathBuf, MigrationError> {
+    let mut path = downloads_dir()?;
+    path.push(did_to_car_filename(did));
+    Ok(path)
+}
+
 /// Convert a DID into the directory / file basename used on disk.
 fn did_to_dirname<D: AsRef<str>>(did: D) -> String {
     did.as_ref().replace(':', "-")
@@ -180,6 +188,47 @@ mod tests {
         let did = Did::new("did:plc:abc123".to_string()).expect("valid test DID");
         let path = did_blobs_path(&did).expect("downloads dir should be readable in tests");
         assert_eq!(path, base.join("did-plc-abc123"));
+    }
+
+    #[test]
+    fn repo_car_path_appends_car_filename_to_base() {
+        let base = downloads_dir().expect("downloads dir should be readable in tests");
+        let path =
+            repo_car_path("did:plc:abc123").expect("downloads dir should be readable in tests");
+        assert_eq!(path, base.join("did-plc-abc123.car"));
+    }
+
+    #[test]
+    fn repo_car_path_accepts_did_type() {
+        let did = Did::new("did:plc:abc123".to_string()).expect("valid test DID");
+        let from_str =
+            repo_car_path("did:plc:abc123").expect("downloads dir should be readable in tests");
+        let from_did = repo_car_path(&did).expect("downloads dir should be readable in tests");
+        assert_eq!(from_str, from_did);
+    }
+
+    #[test]
+    fn repo_car_path_differs_per_did() {
+        let a = repo_car_path("did:plc:aaa").expect("downloads dir should be readable");
+        let b = repo_car_path("did:plc:bbb").expect("downloads dir should be readable");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn repo_car_path_filename_matches_did_to_car_filename() {
+        let did = "did:plc:abc123";
+        let path = repo_car_path(did).expect("downloads dir should be readable");
+        assert_eq!(
+            path.file_name().and_then(|n| n.to_str()),
+            Some(did_to_car_filename(did).as_str())
+        );
+    }
+
+    #[test]
+    fn repo_car_path_is_under_downloads_dir() {
+        let base = downloads_dir().expect("downloads dir should be readable");
+        let path = repo_car_path("did:plc:abc123").expect("downloads dir should be readable");
+        assert_eq!(path.parent(), Some(base.as_path()));
     }
 
     #[test]

--- a/pdsmigration-web/src/api/export_repo.rs
+++ b/pdsmigration-web/src/api/export_repo.rs
@@ -2,7 +2,7 @@ use crate::errors::{ApiError, ApiErrorBody};
 use crate::post;
 use actix_web::web::Json;
 use actix_web::HttpResponse;
-use pdsmigration_common::{did_to_car_filename, downloads_dir, ExportPDSRequest, REDACTED};
+use pdsmigration_common::{did_to_car_filename, repo_car_path, ExportPDSRequest, REDACTED};
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fmt;
@@ -92,14 +92,12 @@ pub async fn export_pds_api(req: Json<ExportPDSApiRequest>) -> Result<HttpRespon
     let bucket_name = "migration".to_string();
     let file_name = did_to_car_filename(&did);
     let key = format!("migration/{file_name}");
-    let file_path = downloads_dir()
-        .map_err(|e| {
-            tracing::error!("[{}] Failed to resolve downloads directory: {}", did, e);
-            ApiError::Runtime {
-                message: e.to_string(),
-            }
-        })?
-        .join(&file_name);
+    let file_path = repo_car_path(&did).map_err(|e| {
+        tracing::error!("[{}] Failed to resolve downloads directory: {}", did, e);
+        ApiError::Runtime {
+            message: e.to_string(),
+        }
+    })?;
 
     tracing::debug!(
         "[{}] Uploading file {} to S3 bucket {} with key {}",

--- a/pdsmigration-web/src/api/export_repo.rs
+++ b/pdsmigration-web/src/api/export_repo.rs
@@ -2,7 +2,7 @@ use crate::errors::{ApiError, ApiErrorBody};
 use crate::post;
 use actix_web::web::Json;
 use actix_web::HttpResponse;
-use pdsmigration_common::{did_to_car_filename, ExportPDSRequest, REDACTED};
+use pdsmigration_common::{did_to_car_filename, downloads_dir, ExportPDSRequest, REDACTED};
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fmt;
@@ -92,18 +92,24 @@ pub async fn export_pds_api(req: Json<ExportPDSApiRequest>) -> Result<HttpRespon
     let bucket_name = "migration".to_string();
     let file_name = did_to_car_filename(&did);
     let key = format!("migration/{file_name}");
+    let file_path = downloads_dir()
+        .map_err(|e| {
+            tracing::error!("[{}] Failed to resolve downloads directory: {}", did, e);
+            ApiError::Runtime {
+                message: e.to_string(),
+            }
+        })?
+        .join(&file_name);
 
     tracing::debug!(
         "[{}] Uploading file {} to S3 bucket {} with key {}",
         did,
-        file_name,
+        file_path.display(),
         bucket_name,
         key
     );
 
-    let body = match aws_sdk_s3::primitives::ByteStream::from_path(std::path::Path::new(&file_name))
-        .await
-    {
+    let body = match aws_sdk_s3::primitives::ByteStream::from_path(&file_path).await {
         Ok(body) => {
             tracing::debug!("[{}] Successfully created ByteStream from file", did);
             body
@@ -112,7 +118,7 @@ pub async fn export_pds_api(req: Json<ExportPDSApiRequest>) -> Result<HttpRespon
             tracing::error!(
                 "[{}] Failed to create ByteStream from file {}: {:?}",
                 did,
-                file_name,
+                file_path.display(),
                 e
             );
             return Err(ApiError::Runtime {

--- a/pdsmigration-web/src/api/import_repo.rs
+++ b/pdsmigration-web/src/api/import_repo.rs
@@ -3,7 +3,7 @@ use crate::errors::{ApiError, ApiErrorBody};
 use crate::post;
 use actix_web::web::{Data, Json};
 use actix_web::HttpResponse;
-use pdsmigration_common::{did_to_car_filename, downloads_dir, ImportPDSRequest, REDACTED};
+use pdsmigration_common::{did_to_car_filename, repo_car_path, ImportPDSRequest, REDACTED};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use utoipa::ToSchema;
@@ -91,11 +91,9 @@ pub async fn import_pds_api(
             message: error.to_string(),
         })?;
 
-    let file_path = downloads_dir()
-        .map_err(|error| ApiError::Runtime {
-            message: error.to_string(),
-        })?
-        .join(&file_name);
+    let file_path = repo_car_path(&did).map_err(|error| ApiError::Runtime {
+        message: error.to_string(),
+    })?;
     std::fs::write(&file_path, body_bytes.into_bytes()).map_err(|error| ApiError::Runtime {
         message: error.to_string(),
     })?;

--- a/pdsmigration-web/src/api/import_repo.rs
+++ b/pdsmigration-web/src/api/import_repo.rs
@@ -3,7 +3,7 @@ use crate::errors::{ApiError, ApiErrorBody};
 use crate::post;
 use actix_web::web::{Data, Json};
 use actix_web::HttpResponse;
-use pdsmigration_common::{did_to_car_filename, ImportPDSRequest, REDACTED};
+use pdsmigration_common::{did_to_car_filename, downloads_dir, ImportPDSRequest, REDACTED};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use utoipa::ToSchema;
@@ -91,7 +91,12 @@ pub async fn import_pds_api(
             message: error.to_string(),
         })?;
 
-    std::fs::write(&file_name, body_bytes.into_bytes()).map_err(|error| ApiError::Runtime {
+    let file_path = downloads_dir()
+        .map_err(|error| ApiError::Runtime {
+            message: error.to_string(),
+        })?
+        .join(&file_name);
+    std::fs::write(&file_path, body_bytes.into_bytes()).map_err(|error| ApiError::Runtime {
         message: error.to_string(),
     })?;
     pdsmigration_common::import_pds_api(req_inner.into()).await?;


### PR DESCRIPTION
## Description

Path used to write and read .car files is not stable after a recent refactor.

## Related Issues

Regression on #94 (deployed earlier today)

## Testing

New tests, more in progress.

## Affected Packages

<!-- Mark all packages affected by this change -->

- [x] `pdsmigration-common` - Core library with migration logic
- [ ] `pdsmigration-gui` - Desktop GUI application (egui/eframe)
- [ ] `pdsmigration-web` - Web service (Actix-Web + AWS S3)
- [ ] Project configuration (Cargo.toml, CI/CD, Docker, etc.)

## Type of Change

<!-- Mark relevant options with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements