### PR TITLE
Fix for bad request on missing blobs flow

### DIFF
--- a/pdsmigration-common/src/agent/account.rs
+++ b/pdsmigration-common/src/agent/account.rs
@@ -112,3 +112,23 @@ pub async fn deactivate_account(agent: &BskyAgent) -> Result<(), MigrationError>
         })?;
     Ok(())
 }
+
+#[tracing::instrument(skip(agent))]
+pub async fn activate_account_agent(agent: &BskyAgent) -> Result<(), MigrationError> {
+    let did = agent.did().await.clone();
+    let did_str = did.as_ref().map(|d| d.as_str()).unwrap_or("unknown");
+    agent
+        .api
+        .com
+        .atproto
+        .server
+        .activate_account()
+        .await
+        .map_err(|error| {
+            tracing::error!("[{}] Failed to activate account: {:?}", did_str, error);
+            MigrationError::Upstream {
+                message: error.to_string(),
+            }
+        })?;
+    Ok(())
+}

--- a/pdsmigration-common/src/agent/blobs.rs
+++ b/pdsmigration-common/src/agent/blobs.rs
@@ -11,6 +11,19 @@ use std::time::Duration;
 
 const DEFAULT_BLOB_REQUEST_TIMEOUT_SECS: u64 = 120;
 
+/// Cooldown applied when an upstream PDS reports we hit its rate limit
+pub const RATE_LIMIT_COOLDOWN_SECS: u64 = 300;
+
+pub async fn wait_for_rate_limit(did: &str, operation: &str) {
+    tracing::error!(
+        did = %did,
+        operation = %operation,
+        cooldown_secs = RATE_LIMIT_COOLDOWN_SECS,
+        "Rate limit reached, waiting before retrying",
+    );
+    tokio::time::sleep(Duration::from_secs(RATE_LIMIT_COOLDOWN_SECS)).await;
+}
+
 /// Shared HTTP client for all blob upload/download requests.
 /// reqwest holds a connection pool internally to improve performance by reusing
 /// connections and avoiding setup overhead
@@ -342,5 +355,10 @@ mod tests {
         let a = blob_http_client();
         let b = blob_http_client();
         assert!(std::ptr::eq(a, b), "shared client should be a singleton");
+    }
+
+    #[test]
+    fn rate_limit_cooldown_is_five_minutes() {
+        assert_eq!(RATE_LIMIT_COOLDOWN_SECS, 300);
     }
 }

--- a/pdsmigration-common/src/export_all_blobs.rs
+++ b/pdsmigration-common/src/export_all_blobs.rs
@@ -1,11 +1,10 @@
-use crate::agent::{download_blob, list_all_blobs, login_helper};
+use crate::agent::{download_blob, list_all_blobs, login_helper, wait_for_rate_limit};
 use crate::{build_agent, did_blobs_path, format_cid, MigrationError, REDACTED};
 use bsky_sdk::api::types::string::Did;
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::io::ErrorKind;
-use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 
 #[derive(Deserialize, Serialize)]
@@ -108,9 +107,7 @@ pub async fn export_all_blobs_api(
                 Err(e) => {
                     match e {
                         MigrationError::RateLimitReached => {
-                            tracing::error!("[{}] Rate limit reached, waiting 5 minutes", did);
-                            let five_minutes = Duration::from_secs(300);
-                            tokio::time::sleep(five_minutes).await;
+                            wait_for_rate_limit(did, "export_all_blobs").await;
                         }
                         _ => {
                             //todo

--- a/pdsmigration-common/src/export_blobs.rs
+++ b/pdsmigration-common/src/export_blobs.rs
@@ -1,10 +1,9 @@
-use crate::agent::{download_blob, login_helper, missing_blobs};
+use crate::agent::{download_blob, login_helper, missing_blobs, wait_for_rate_limit};
 use crate::export_all_blobs::GetBlobRequest;
 use crate::{build_agent, did_blobs_path, format_cid, MigrationError, REDACTED};
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::io::ErrorKind;
-use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 
 #[derive(Deserialize, Serialize)]
@@ -131,9 +130,7 @@ pub async fn export_blobs_api(
                 Err(e) => {
                     match e {
                         MigrationError::RateLimitReached => {
-                            tracing::error!("[{}] Rate limit reached, waiting 5 minutes", did);
-                            let five_minutes = Duration::from_secs(300);
-                            tokio::time::sleep(five_minutes).await;
+                            wait_for_rate_limit(did, "export_blobs").await;
                         }
                         _ => {
                             tracing::error!("[{}] Failed to determine missing blobs", did);

--- a/pdsmigration-common/src/export_pds.rs
+++ b/pdsmigration-common/src/export_pds.rs
@@ -1,8 +1,7 @@
-use crate::agent::{download_repo, login_helper};
+use crate::agent::{download_repo, login_helper, wait_for_rate_limit};
 use crate::{build_agent, repo_car_path, GetRepoRequest, MigrationError, REDACTED};
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 
 #[derive(Deserialize, Serialize)]
@@ -91,9 +90,7 @@ pub async fn export_pds_api(req: ExportPDSRequest) -> Result<(), MigrationError>
         Err(e) => {
             match e {
                 MigrationError::RateLimitReached => {
-                    tracing::error!("[{}] Rate limit reached, waiting 5 minutes", did);
-                    let five_minutes = Duration::from_secs(300);
-                    tokio::time::sleep(five_minutes).await;
+                    wait_for_rate_limit(did, "export_pds").await;
                 }
                 _ => {
                     tracing::error!("[{}] Failed to download repo", did);

--- a/pdsmigration-common/tests/agent_account.rs
+++ b/pdsmigration-common/tests/agent_account.rs
@@ -19,11 +19,7 @@ async fn mount_get_session(server: &MockServer, did: &str) {
         .await;
 }
 
-async fn logged_in_agent(
-    server: &MockServer,
-    did: &str,
-    token: &str,
-) -> bsky_sdk::BskyAgent {
+async fn logged_in_agent(server: &MockServer, did: &str, token: &str) -> bsky_sdk::BskyAgent {
     let agent = build_agent().await.expect("build_agent should succeed");
     agent.configure_endpoint(server.uri());
     login_helper(&agent, &server.uri(), did, token)

--- a/pdsmigration-common/tests/agent_account.rs
+++ b/pdsmigration-common/tests/agent_account.rs
@@ -1,0 +1,215 @@
+use bsky_sdk::api::agent::Configure;
+use pdsmigration_common::{
+    activate_account_agent, build_agent, deactivate_account, login_helper, unique_did,
+    MigrationError,
+};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+async fn mount_get_session(server: &MockServer, did: &str) {
+    Mock::given(method("GET"))
+        .and(path("/xrpc/com.atproto.server.getSession"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "did": did,
+            "handle": "anothermigration.bsky.social",
+            "active": true,
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn logged_in_agent(
+    server: &MockServer,
+    did: &str,
+    token: &str,
+) -> bsky_sdk::BskyAgent {
+    let agent = build_agent().await.expect("build_agent should succeed");
+    agent.configure_endpoint(server.uri());
+    login_helper(&agent, &server.uri(), did, token)
+        .await
+        .expect("login_helper should resume the mocked session");
+    agent
+}
+
+#[tokio::test]
+async fn activate_account_agent_happy_returns_ok() {
+    let server = MockServer::start().await;
+    let did = unique_did("activatehappy");
+    mount_get_session(&server, &did).await;
+
+    Mock::given(method("POST"))
+        .and(path("/xrpc/com.atproto.server.activateAccount"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let agent = logged_in_agent(&server, &did, "origin-jwt").await;
+    activate_account_agent(&agent)
+        .await
+        .expect("activate_account_agent should succeed on 200");
+
+    let received = server.received_requests().await.expect("requests recorded");
+    let activate_calls: Vec<_> = received
+        .iter()
+        .filter(|r| r.url.path() == "/xrpc/com.atproto.server.activateAccount")
+        .collect();
+    assert_eq!(
+        activate_calls.len(),
+        1,
+        "activateAccount should be called exactly once"
+    );
+
+    let auth = activate_calls[0]
+        .headers
+        .get("authorization")
+        .map(|v| v.to_str().unwrap_or("").to_string())
+        .unwrap_or_default();
+    assert_eq!(
+        auth, "Bearer origin-jwt",
+        "activateAccount must forward the bearer token"
+    );
+
+    let deactivate_calls = received
+        .iter()
+        .filter(|r| r.url.path() == "/xrpc/com.atproto.server.deactivateAccount")
+        .count();
+    assert_eq!(
+        deactivate_calls, 0,
+        "activate must not also call deactivateAccount"
+    );
+}
+
+#[tokio::test]
+async fn activate_account_agent_upstream_error_maps_to_upstream() {
+    let server = MockServer::start().await;
+    let did = unique_did("activate500");
+    mount_get_session(&server, &did).await;
+
+    Mock::given(method("POST"))
+        .and(path("/xrpc/com.atproto.server.activateAccount"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+        .mount(&server)
+        .await;
+
+    let agent = logged_in_agent(&server, &did, "origin-jwt").await;
+    let err = match activate_account_agent(&agent).await {
+        Ok(()) => panic!("a 500 on activateAccount must surface as an error"),
+        Err(e) => e,
+    };
+    assert!(
+        matches!(err, MigrationError::Upstream { .. }),
+        "expected MigrationError::Upstream, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn deactivate_account_happy_returns_ok() {
+    let server = MockServer::start().await;
+    let did = unique_did("deactivatehappy");
+    mount_get_session(&server, &did).await;
+
+    Mock::given(method("POST"))
+        .and(path("/xrpc/com.atproto.server.deactivateAccount"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let agent = logged_in_agent(&server, &did, "origin-jwt").await;
+    deactivate_account(&agent)
+        .await
+        .expect("deactivate_account should succeed on 200");
+
+    let received = server.received_requests().await.expect("requests recorded");
+    let deactivate_calls: Vec<_> = received
+        .iter()
+        .filter(|r| r.url.path() == "/xrpc/com.atproto.server.deactivateAccount")
+        .collect();
+    assert_eq!(
+        deactivate_calls.len(),
+        1,
+        "deactivateAccount should be called exactly once"
+    );
+
+    let auth = deactivate_calls[0]
+        .headers
+        .get("authorization")
+        .map(|v| v.to_str().unwrap_or("").to_string())
+        .unwrap_or_default();
+    assert_eq!(
+        auth, "Bearer origin-jwt",
+        "deactivateAccount must forward the bearer token"
+    );
+
+    // Body should be a JSON object (deleteAfter omitted is fine).
+    let content_type = deactivate_calls[0]
+        .headers
+        .get("content-type")
+        .map(|v| v.to_str().unwrap_or("").to_string())
+        .unwrap_or_default();
+    assert!(
+        content_type.starts_with("application/json"),
+        "deactivateAccount should send JSON, got content-type {content_type:?}"
+    );
+
+    let activate_calls = received
+        .iter()
+        .filter(|r| r.url.path() == "/xrpc/com.atproto.server.activateAccount")
+        .count();
+    assert_eq!(
+        activate_calls, 0,
+        "deactivate must not also call activateAccount"
+    );
+}
+
+#[tokio::test]
+async fn deactivate_account_error_maps_to_runtime() {
+    let server = MockServer::start().await;
+    let did = unique_did("deactivate500");
+    mount_get_session(&server, &did).await;
+
+    Mock::given(method("POST"))
+        .and(path("/xrpc/com.atproto.server.deactivateAccount"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+        .mount(&server)
+        .await;
+
+    let agent = logged_in_agent(&server, &did, "origin-jwt").await;
+    let err = match deactivate_account(&agent).await {
+        Ok(()) => panic!("a 500 on deactivateAccount must surface as an error"),
+        Err(e) => e,
+    };
+    assert!(
+        matches!(err, MigrationError::Runtime { .. }),
+        "expected MigrationError::Runtime, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn activate_account_agent_idempotent_returns_ok() {
+    let server = MockServer::start().await;
+    let did = unique_did("activateidempotent");
+    mount_get_session(&server, &did).await;
+
+    Mock::given(method("POST"))
+        .and(path("/xrpc/com.atproto.server.activateAccount"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let agent = logged_in_agent(&server, &did, "origin-jwt").await;
+    activate_account_agent(&agent).await.expect("first call ok");
+    activate_account_agent(&agent)
+        .await
+        .expect("second call ok (idempotent)");
+
+    let received = server.received_requests().await.expect("requests recorded");
+    let activate_calls = received
+        .iter()
+        .filter(|r| r.url.path() == "/xrpc/com.atproto.server.activateAccount")
+        .count();
+    assert_eq!(
+        activate_calls, 2,
+        "two calls should produce two activateAccount requests, no retries"
+    );
+}

--- a/pdsmigration-web/src/background_jobs.rs
+++ b/pdsmigration-web/src/background_jobs.rs
@@ -4,8 +4,8 @@ use derive_more::Display;
 use futures_util::StreamExt;
 use pdsmigration_common::{
     activate_account_agent, build_agent, deactivate_account, did_blobs_path, download_blob,
-    format_cid, login_helper, missing_blobs, upload_blob_v2, ExportBlobsRequest, GetBlobRequest,
-    MigrationError, UploadBlobsRequest,
+    format_cid, login_helper, missing_blobs, upload_blob_v2, wait_for_rate_limit,
+    ExportBlobsRequest, GetBlobRequest, MigrationError, UploadBlobsRequest,
 };
 use serde::{Deserialize, Serialize};
 #[allow(unused_imports)] // Used in schema attribute macros
@@ -145,9 +145,7 @@ impl JobState {
 
     pub fn finalize(&mut self, id: Uuid, result: Result<(), MigrationError>) {
         if let Some(r) = self.records.get_mut(&id) {
-            let elapsed_ms = r
-                .started_at
-                .map(|s| now_millis().saturating_sub(s));
+            let elapsed_ms = r.started_at.map(|s| now_millis().saturating_sub(s));
             let progress = r.progress.clone().unwrap_or_default();
             match result {
                 Ok(_) => {
@@ -426,7 +424,7 @@ async fn export_blobs_api_job(
                 }
                 Err(e) => {
                     if matches!(e, MigrationError::RateLimitReached) {
-                        wait_for_rate_limit(did, JobKind::ExportBlobs).await;
+                        wait_for_rate_limit(did, &JobKind::ExportBlobs.to_string()).await;
                     }
                     tracing::error!(
                         did = %did,
@@ -637,7 +635,7 @@ async fn upload_blob_with_retries(
                     return Err(MigrationError::RateLimitReached);
                 }
                 rate_limit_waits += 1;
-                wait_for_rate_limit(did, JobKind::UploadBlobs).await;
+                wait_for_rate_limit(did, &JobKind::UploadBlobs.to_string()).await;
             }
             Err(e) => {
                 if !matches!(e, MigrationError::Upstream { .. }) || attempt >= max_attempts {
@@ -658,16 +656,6 @@ async fn upload_blob_with_retries(
             }
         }
     }
-}
-
-/// Sleep for the standard rate-limit cooldown
-async fn wait_for_rate_limit(did: &str, operation: JobKind) {
-    tracing::error!(
-        "[{}][{}] Rate limit reached, waiting 5 minutes",
-        did,
-        operation
-    );
-    tokio::time::sleep(Duration::from_secs(300)).await;
 }
 
 #[cfg(test)]

--- a/pdsmigration-web/src/background_jobs.rs
+++ b/pdsmigration-web/src/background_jobs.rs
@@ -3,8 +3,9 @@ use bsky_sdk::api::agent::Configure;
 use derive_more::Display;
 use futures_util::StreamExt;
 use pdsmigration_common::{
-    build_agent, did_blobs_path, download_blob, format_cid, login_helper, missing_blobs,
-    upload_blob_v2, ExportBlobsRequest, GetBlobRequest, MigrationError, UploadBlobsRequest,
+    activate_account_agent, build_agent, deactivate_account, did_blobs_path, download_blob,
+    format_cid, login_helper, missing_blobs, upload_blob_v2, ExportBlobsRequest, GetBlobRequest,
+    MigrationError, UploadBlobsRequest,
 };
 use serde::{Deserialize, Serialize};
 #[allow(unused_imports)] // Used in schema attribute macros
@@ -298,6 +299,33 @@ async fn export_blobs_api_job(
 
     let did_blobs_path = did_blobs_path(&session.did)?;
     let did = session.did.as_str();
+
+    // on missing blob requests, the origin PDS may reject `sync` operations
+    // if the account is deactivated (expected after a successful migration),
+    // so we temporarily reactivate it to fetch missing blobs
+    let origin_was_deactivated = if req.is_missing_blob_request {
+        match agent.api.com.atproto.server.get_session().await {
+            Ok(output) => output.active == Some(false),
+            Err(error) => {
+                tracing::warn!(
+                    "[{}] Could not query origin session to check activation state: {}",
+                    did,
+                    error
+                );
+                false
+            }
+        }
+    } else {
+        false
+    };
+    if origin_was_deactivated {
+        tracing::info!(
+            "[{}] Origin reports deactivated; reactivating temporarily to download missing blobs",
+            did
+        );
+        activate_account_agent(&agent).await?;
+    }
+
     if req.is_missing_blob_request {
         if let Err(e) = tokio::fs::remove_dir_all(did_blobs_path.as_path()).await {
             if e.kind() != ErrorKind::NotFound {
@@ -382,6 +410,19 @@ async fn export_blobs_api_job(
                     }
                 }
             }
+        }
+    }
+    if origin_was_deactivated {
+        tracing::info!(
+            "[{}] Restoring origin to deactivated state after missing-blob download",
+            did
+        );
+        if let Err(error) = deactivate_account(&agent).await {
+            tracing::warn!(
+                "[{}] Failed to re-deactivate origin after missing-blob download: {}",
+                did,
+                error
+            );
         }
     }
     Ok(())

--- a/pdsmigration-web/src/background_jobs.rs
+++ b/pdsmigration-web/src/background_jobs.rs
@@ -135,21 +135,52 @@ impl JobState {
         if let Some(r) = self.records.get_mut(&id) {
             r.status = JobStatus::Running;
             r.started_at = Some(now_millis());
+            tracing::info!(
+                job_id = %r.id,
+                kind = %r.kind,
+                "Job status: Queued -> Running",
+            );
         }
     }
 
     pub fn finalize(&mut self, id: Uuid, result: Result<(), MigrationError>) {
         if let Some(r) = self.records.get_mut(&id) {
+            let elapsed_ms = r
+                .started_at
+                .map(|s| now_millis().saturating_sub(s));
+            let progress = r.progress.clone().unwrap_or_default();
             match result {
                 Ok(_) => {
                     r.status = JobStatus::Success;
+                    r.finished_at = Some(now_millis());
+                    tracing::info!(
+                        job_id = %r.id,
+                        kind = %r.kind,
+                        elapsed_ms = elapsed_ms.unwrap_or(0),
+                        successful_blobs = progress.successful_blobs,
+                        invalid_blobs = progress.invalid_blobs,
+                        total = progress.total.unwrap_or(0),
+                        "Job finished: Running -> Success",
+                    );
                 }
                 Err(e) => {
+                    let msg = format!("{}", e);
                     r.status = JobStatus::Error;
-                    r.error = Some(format!("{}", e));
+                    r.error = Some(msg.clone());
+                    r.finished_at = Some(now_millis());
+                    tracing::error!(
+                        job_id = %r.id,
+                        kind = %r.kind,
+                        elapsed_ms = elapsed_ms.unwrap_or(0),
+                        successful_blobs = progress.successful_blobs,
+                        invalid_blobs = progress.invalid_blobs,
+                        total = progress.total.unwrap_or(0),
+                        error = %msg,
+                        error_debug = ?e,
+                        "Job errored: Running -> Error",
+                    );
                 }
             }
-            r.finished_at = Some(now_millis());
         }
     }
 
@@ -398,11 +429,13 @@ async fn export_blobs_api_job(
                         wait_for_rate_limit(did, JobKind::ExportBlobs).await;
                     }
                     tracing::error!(
-                        "[{}][{}] Failed to process blob {}: {}",
-                        did,
-                        JobKind::ExportBlobs,
-                        blob_cid_str,
-                        e
+                        did = %did,
+                        kind = %JobKind::ExportBlobs,
+                        cid = %blob_cid_str,
+                        step = "download_blob",
+                        error = %e,
+                        error_debug = ?e,
+                        "Failed to process blob",
                     );
                     {
                         let mut st = state.write().await;
@@ -452,7 +485,12 @@ async fn upload_blobs_api_job(
     match tokio::fs::read_dir(path.as_path()).await {
         Ok(output) => blob_dir = output,
         Err(error) => {
-            tracing::error!("[{}] {}", did, error.to_string());
+            tracing::error!(
+                did = %did,
+                path = %path.display(),
+                error = %error,
+                "Failed to read blob directory",
+            );
             return Err(MigrationError::Runtime {
                 message: "Failed to read blob directory".to_string(),
             });

--- a/pdsmigration-web/tests/blob_jobs_deactivated_origin.rs
+++ b/pdsmigration-web/tests/blob_jobs_deactivated_origin.rs
@@ -1,0 +1,310 @@
+use pdsmigration_common::{did_blobs_path, ExportBlobsRequest};
+use pdsmigration_web::background_jobs::{JobManager, JobStatus};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+mod common;
+use common::{await_job, unique_did};
+
+#[tokio::test]
+async fn export_blobs_job_reactivates_deactivated_origin() {
+    let origin = MockServer::start().await;
+    let destination = MockServer::start().await;
+
+    let did = unique_did("webjobdeactivatedorigin");
+    let payload: &[u8] = b"fake-blob-bytes-after-reactivation";
+    let blob_cid = "bafyreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy";
+    let record_uri = format!("at://{did}/app.bsky.feed.post/abc123");
+
+    // Origin reports the account as deactivated.
+    Mock::given(method("GET"))
+        .and(path("/xrpc/com.atproto.server.getSession"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "did": did,
+            "handle": "anothermigration.bsky.social",
+            "active": false,
+            "status": "deactivated",
+        })))
+        .mount(&origin)
+        .await;
+
+    // Destination reports as active (default test session body).
+    Mock::given(method("GET"))
+        .and(path("/xrpc/com.atproto.server.getSession"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "did": did,
+            "handle": "anothermigration.bsky.social",
+            "active": true,
+        })))
+        .mount(&destination)
+        .await;
+
+    // Destination reports one missing blob.
+    Mock::given(method("GET"))
+        .and(path("/xrpc/com.atproto.repo.listMissingBlobs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "blobs": [{
+                "cid": blob_cid,
+                "recordUri": record_uri,
+            }],
+        })))
+        .mount(&destination)
+        .await;
+
+    // Origin accepts activate and deactivate, and streams the blob bytes.
+    Mock::given(method("POST"))
+        .and(path("/xrpc/com.atproto.server.activateAccount"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&origin)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/xrpc/com.atproto.server.deactivateAccount"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&origin)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/xrpc/com.atproto.sync.getBlob"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("ratelimit-remaining", "1000")
+                .set_body_bytes(payload),
+        )
+        .mount(&origin)
+        .await;
+
+    let blob_dir = did_blobs_path(&did).expect("downloads dir resolvable");
+    let _ = std::fs::remove_dir_all(&blob_dir);
+
+    let jobs = JobManager::new();
+    let export_id = jobs
+        .spawn_export_blobs(ExportBlobsRequest {
+            destination: destination.uri(),
+            origin: origin.uri(),
+            did: did.clone(),
+            origin_token: "origin-jwt".to_string(),
+            destination_token: "destination-jwt".to_string(),
+            is_missing_blob_request: true,
+        })
+        .await
+        .expect("spawn_export_blobs should accept the request");
+
+    assert_eq!(
+        await_job(&jobs, export_id).await,
+        JobStatus::Success,
+        "export job should finish successfully even when origin is deactivated"
+    );
+
+    let received = origin
+        .received_requests()
+        .await
+        .expect("wiremock should record requests");
+    let activate_calls = received
+        .iter()
+        .filter(|r| r.url.path() == "/xrpc/com.atproto.server.activateAccount")
+        .count();
+    let deactivate_calls = received
+        .iter()
+        .filter(|r| r.url.path() == "/xrpc/com.atproto.server.deactivateAccount")
+        .count();
+    let blob_calls = received
+        .iter()
+        .filter(|r| r.url.path() == "/xrpc/com.atproto.sync.getBlob")
+        .count();
+    assert_eq!(
+        activate_calls, 1,
+        "origin should be reactivated exactly once"
+    );
+    assert_eq!(
+        deactivate_calls, 1,
+        "origin should be re-deactivated exactly once after the download"
+    );
+    assert_eq!(
+        blob_calls, 1,
+        "getBlob should have been called for the missing blob"
+    );
+
+    // Blob bytes should have made it to disk.
+    let on_disk = std::fs::read(blob_dir.join(blob_cid))
+        .expect("export job should have written the blob file");
+    assert_eq!(on_disk, payload);
+
+    let _ = std::fs::remove_dir_all(&blob_dir);
+}
+
+#[tokio::test]
+async fn export_blobs_job_leaves_active_origin_untouched() {
+    let origin = MockServer::start().await;
+    let destination = MockServer::start().await;
+
+    let did = unique_did("webjobactiveorigin");
+    let payload: &[u8] = b"fake-blob-bytes-active-origin";
+    let blob_cid = "bafyreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy";
+    let record_uri = format!("at://{did}/app.bsky.feed.post/abc123");
+
+    let session_body = json!({
+        "did": did,
+        "handle": "anothermigration.bsky.social",
+        "active": true,
+    });
+    for server in [&origin, &destination] {
+        Mock::given(method("GET"))
+            .and(path("/xrpc/com.atproto.server.getSession"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&session_body))
+            .mount(server)
+            .await;
+    }
+
+    Mock::given(method("GET"))
+        .and(path("/xrpc/com.atproto.repo.listMissingBlobs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "blobs": [{
+                "cid": blob_cid,
+                "recordUri": record_uri,
+            }],
+        })))
+        .mount(&destination)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/xrpc/com.atproto.sync.getBlob"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("ratelimit-remaining", "1000")
+                .set_body_bytes(payload),
+        )
+        .mount(&origin)
+        .await;
+
+    let blob_dir = did_blobs_path(&did).expect("downloads dir resolvable");
+    let _ = std::fs::remove_dir_all(&blob_dir);
+
+    let jobs = JobManager::new();
+    let export_id = jobs
+        .spawn_export_blobs(ExportBlobsRequest {
+            destination: destination.uri(),
+            origin: origin.uri(),
+            did: did.clone(),
+            origin_token: "origin-jwt".to_string(),
+            destination_token: "destination-jwt".to_string(),
+            is_missing_blob_request: true,
+        })
+        .await
+        .expect("spawn_export_blobs should accept the request");
+
+    assert_eq!(
+        await_job(&jobs, export_id).await,
+        JobStatus::Success,
+        "export job should finish successfully for an active origin"
+    );
+
+    let received = origin
+        .received_requests()
+        .await
+        .expect("wiremock should record requests");
+    let activate_calls = received
+        .iter()
+        .filter(|r| r.url.path() == "/xrpc/com.atproto.server.activateAccount")
+        .count();
+    let deactivate_calls = received
+        .iter()
+        .filter(|r| r.url.path() == "/xrpc/com.atproto.server.deactivateAccount")
+        .count();
+    assert_eq!(
+        activate_calls, 0,
+        "activateAccount must not be called when origin is already active"
+    );
+    assert_eq!(
+        deactivate_calls, 0,
+        "deactivateAccount must not be called when origin is already active"
+    );
+
+    let _ = std::fs::remove_dir_all(&blob_dir);
+}
+
+#[tokio::test]
+async fn export_blobs_job_skips_activation_check_on_regular_flow() {
+    let origin = MockServer::start().await;
+    let destination = MockServer::start().await;
+
+    let did = unique_did("webjobregularflow");
+    let payload: &[u8] = b"fake-blob-bytes-regular-flow";
+    let blob_cid = "bafyreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy";
+    let record_uri = format!("at://{did}/app.bsky.feed.post/abc123");
+
+    let session_body = json!({
+        "did": did,
+        "handle": "anothermigration.bsky.social",
+        "active": true,
+    });
+    for server in [&origin, &destination] {
+        Mock::given(method("GET"))
+            .and(path("/xrpc/com.atproto.server.getSession"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&session_body))
+            .mount(server)
+            .await;
+    }
+
+    Mock::given(method("GET"))
+        .and(path("/xrpc/com.atproto.repo.listMissingBlobs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "blobs": [{
+                "cid": blob_cid,
+                "recordUri": record_uri,
+            }],
+        })))
+        .mount(&destination)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/xrpc/com.atproto.sync.getBlob"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("ratelimit-remaining", "1000")
+                .set_body_bytes(payload),
+        )
+        .mount(&origin)
+        .await;
+
+    let blob_dir = did_blobs_path(&did).expect("downloads dir resolvable");
+    let _ = std::fs::remove_dir_all(&blob_dir);
+
+    let jobs = JobManager::new();
+    let export_id = jobs
+        .spawn_export_blobs(ExportBlobsRequest {
+            destination: destination.uri(),
+            origin: origin.uri(),
+            did: did.clone(),
+            origin_token: "origin-jwt".to_string(),
+            destination_token: "destination-jwt".to_string(),
+            is_missing_blob_request: false,
+        })
+        .await
+        .expect("spawn_export_blobs should accept the request");
+
+    assert_eq!(
+        await_job(&jobs, export_id).await,
+        JobStatus::Success,
+        "regular-flow export job should finish successfully"
+    );
+
+    let received = origin
+        .received_requests()
+        .await
+        .expect("wiremock should record requests");
+    let activate_calls = received
+        .iter()
+        .filter(|r| r.url.path() == "/xrpc/com.atproto.server.activateAccount")
+        .count();
+    let deactivate_calls = received
+        .iter()
+        .filter(|r| r.url.path() == "/xrpc/com.atproto.server.deactivateAccount")
+        .count();
+    assert_eq!(activate_calls, 0, "regular flow must not reactivate origin");
+    assert_eq!(
+        deactivate_calls, 0,
+        "regular flow must not re-deactivate origin"
+    );
+
+    let _ = std::fs::remove_dir_all(&blob_dir);
+}


### PR DESCRIPTION
## Description

1. If needed, only during `missing-blobs` flow, temporarily reactivate the origin account to get all blobs from the `sync` endpoints, and deactivate again at the end of the operation.
2. Improved logs for blobs export/import jobs
3. Add unit and integration tests covering this edge case.

## Related Issues

<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing

New and existing unit tests pass.

Validated with a test account on a self-hosted PDS.

<!-- Describe the tests you ran to verify your changes -->

## Affected Packages

<!-- Mark all packages affected by this change -->

- [x] `pdsmigration-common` - Core library with migration logic
- [ ] `pdsmigration-gui` - Desktop GUI application (egui/eframe)
- [x] `pdsmigration-web` - Web service (Actix-Web + AWS S3)
- [ ] Project configuration (Cargo.toml, CI/CD, Docker, etc.)

## Type of Change

<!-- Mark relevant options with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [x] Test improvements