### PR TITLE
Set up new job API endpoint for repo exports

### DIFF
--- a/pdsmigration-web/src/api/export_repo.rs
+++ b/pdsmigration-web/src/api/export_repo.rs
@@ -1,12 +1,14 @@
+use crate::api::EnqueueJobResponse;
+use crate::background_jobs::{export_repo_to_s3, JobManager};
+use crate::config::AppConfig;
 use crate::errors::{ApiError, ApiErrorBody};
 use crate::post;
-use actix_web::web::Json;
-use actix_web::HttpResponse;
-use pdsmigration_common::{did_to_car_filename, repo_car_path, ExportPDSRequest, REDACTED};
+use crate::Json;
+use actix_web::{web, HttpResponse};
+use pdsmigration_common::{ExportPDSRequest, REDACTED};
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fmt;
-use std::time::Instant;
 use utoipa::ToSchema;
 
 #[derive(Deserialize, Serialize, ToSchema)]
@@ -56,23 +58,6 @@ impl From<ExportPDSApiRequest> for ExportPDSRequest {
 pub async fn export_pds_api(req: Json<ExportPDSApiRequest>) -> Result<HttpResponse, ApiError> {
     let req_inner = req.into_inner();
     let did = req_inner.did.clone();
-    tracing::info!("[{}] Export repository request received", did);
-    let download_start = Instant::now();
-    pdsmigration_common::export_pds_api(req_inner.into())
-        .await
-        .map_err(|e| {
-            tracing::error!("[{}] Failed to export repository: {}", did, e);
-            ApiError::Runtime {
-                message: e.to_string(),
-            }
-        })?;
-    tracing::info!(
-        "[{}] Repository download phase finished in {:.1}s, starting S3 upload",
-        did,
-        download_start.elapsed().as_secs_f64()
-    );
-
-    // Upload the downloaded file to AWS S3
     let endpoint_url = env::var("ENDPOINT").map_err(|e| {
         tracing::error!(
             "[{}] Failed to get ENDPOINT environment variable: {}",
@@ -83,97 +68,11 @@ pub async fn export_pds_api(req: Json<ExportPDSApiRequest>) -> Result<HttpRespon
             message: e.to_string(),
         }
     })?;
-
-    tracing::debug!(
-        "[{}] Loading AWS config with endpoint: {}",
-        did,
-        endpoint_url
-    );
-    let config = aws_config::from_env()
-        .region("auto")
-        .endpoint_url(&endpoint_url)
-        .load()
-        .await;
-    let client = aws_sdk_s3::Client::new(&config);
-
-    let bucket_name = "migration".to_string();
-    let file_name = did_to_car_filename(&did);
-    let key = format!("migration/{file_name}");
-    let file_path = repo_car_path(&did).map_err(|e| {
-        tracing::error!("[{}] Failed to resolve downloads directory: {}", did, e);
-        ApiError::Runtime {
-            message: e.to_string(),
-        }
-    })?;
-
-    tracing::debug!(
-        "[{}] Uploading file {} to S3 bucket {} with key {}",
-        did,
-        file_path.display(),
-        bucket_name,
-        key
-    );
-
-    match tokio::fs::metadata(&file_path).await {
-        Ok(meta) => tracing::info!(
-            "[{}] Exported repository file size: {} bytes",
-            did,
-            meta.len()
-        ),
-        Err(e) => tracing::warn!(
-            "[{}] Failed to read exported repository file metadata: {:?}",
-            did,
-            e
-        ),
-    }
-
-    let upload_start = Instant::now();
-    let body = match aws_sdk_s3::primitives::ByteStream::from_path(&file_path).await {
-        Ok(body) => {
-            tracing::debug!("[{}] Successfully created ByteStream from file", did);
-            body
-        }
-        Err(e) => {
-            tracing::error!(
-                "[{}] Failed to create ByteStream from file {}: {:?}",
-                did,
-                file_path.display(),
-                e
-            );
-            return Err(ApiError::Runtime {
-                message: e.to_string(),
-            });
-        }
-    };
-
-    match client
-        .put_object()
-        .bucket(&bucket_name)
-        .key(&key)
-        .body(body)
-        .send()
+    export_repo_to_s3(req_inner.into(), &endpoint_url)
         .await
-    {
-        Ok(_) => {}
-        Err(e) => {
-            tracing::error!(
-                "[{}] Failed to upload to S3: bucket={}, key={}, error={:?}",
-                did,
-                bucket_name,
-                key,
-                e
-            );
-            return Err(ApiError::Runtime {
-                message: e.to_string(),
-            });
-        }
-    };
-
-    tracing::info!(
-        "[{}] Repository exported and uploaded to S3 successfully (upload phase {:.1}s)",
-        did,
-        upload_start.elapsed().as_secs_f64()
-    );
+        .map_err(|e| ApiError::Runtime {
+            message: e.to_string(),
+        })?;
     let response = HttpResponse::Ok().finish();
     tracing::info!(
         "[{}] Export repository request complete, returning HTTP {}",
@@ -181,6 +80,40 @@ pub async fn export_pds_api(req: Json<ExportPDSApiRequest>) -> Result<HttpRespon
         response.status()
     );
     Ok(response)
+}
+
+#[utoipa::path(
+    post,
+    path = "/jobs/export-repo",
+    request_body = ExportPDSApiRequest,
+    responses(
+        (status = 202, description = "Job enqueued", body = EnqueueJobResponse, content_type = "application/json"),
+        (status = 400, description = "Invalid request", body = ApiErrorBody, content_type = "application/json"),
+        (status = 401, description = "Authentication error", body = ApiErrorBody, content_type = "application/json"),
+        (status = 429, description = "Rate limit exceeded", body = ApiErrorBody, content_type = "application/json"),
+    ),
+    tag = "pdsmigration-web"
+)]
+#[tracing::instrument(skip(jobs, config, req))]
+#[post("/jobs/export-repo")]
+pub async fn enqueue_export_repo_job_api(
+    jobs: web::Data<JobManager>,
+    config: web::Data<AppConfig>,
+    req: Json<ExportPDSApiRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let req_inner = req.into_inner();
+    let did = req_inner.did.clone();
+    tracing::info!("[{}] Enqueueing export-repo job", did);
+    let id = jobs
+        .spawn_export_repo(
+            ExportPDSRequest::from(req_inner),
+            config.external_services.s3_endpoint.clone(),
+        )
+        .await?;
+    tracing::info!("[{}] Enqueued export-repo job {}", did, id);
+    Ok(HttpResponse::Accepted().json(EnqueueJobResponse {
+        job_id: id.to_string(),
+    }))
 }
 
 #[cfg(test)]

--- a/pdsmigration-web/src/background_jobs.rs
+++ b/pdsmigration-web/src/background_jobs.rs
@@ -3,9 +3,10 @@ use bsky_sdk::api::agent::Configure;
 use derive_more::Display;
 use futures_util::StreamExt;
 use pdsmigration_common::{
-    activate_account_agent, build_agent, deactivate_account, did_blobs_path, download_blob,
-    format_cid, login_helper, missing_blobs, upload_blob_v2, wait_for_rate_limit,
-    ExportBlobsRequest, GetBlobRequest, MigrationError, UploadBlobsRequest,
+    activate_account_agent, build_agent, deactivate_account, did_blobs_path, did_to_car_filename,
+    download_blob, format_cid, login_helper, missing_blobs, repo_car_path, upload_blob_v2,
+    wait_for_rate_limit, ExportBlobsRequest, ExportPDSRequest, GetBlobRequest, MigrationError,
+    UploadBlobsRequest,
 };
 use serde::{Deserialize, Serialize};
 #[allow(unused_imports)] // Used in schema attribute macros
@@ -13,7 +14,7 @@ use serde_json::json;
 use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::RwLock;
 use utoipa::ToSchema;
@@ -57,6 +58,7 @@ fn now_millis() -> u64 {
 pub enum JobKind {
     ExportBlobs,
     UploadBlobs,
+    ExportRepo,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
@@ -283,6 +285,40 @@ impl JobManager {
                 st.set_running(id);
             }
             let result = export_blobs_api_job(id, state.clone(), request).await;
+            {
+                let mut st = state.write().await;
+                st.finalize(id, result);
+            }
+        });
+
+        Ok(id)
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn spawn_export_repo(
+        &self,
+        request: ExportPDSRequest,
+        s3_endpoint: String,
+    ) -> Result<Uuid, ApiError> {
+        let id = Uuid::new_v4();
+        let did = request.did.clone();
+        let pds_host = request.pds_host.clone();
+        tracing::info!("[{}] Spawning export_repo job {} for {}", did, id, pds_host);
+        let rec = JobRecord::new(id, JobKind::ExportRepo);
+
+        {
+            let mut st = self.state.write().await;
+            st.records.insert(id, rec);
+            st.update_total(id, 1);
+        }
+
+        let state = self.state.clone();
+        tokio::spawn(async move {
+            {
+                let mut st = state.write().await;
+                st.set_running(id);
+            }
+            let result = export_repo_api_job(id, state.clone(), request, s3_endpoint).await;
             {
                 let mut st = state.write().await;
                 st.finalize(id, result);
@@ -611,6 +647,108 @@ async fn upload_blobs_api_job(
     Ok(())
 }
 
+#[tracing::instrument(skip(state, req))]
+async fn export_repo_api_job(
+    id: Uuid,
+    state: Arc<RwLock<JobState>>,
+    req: ExportPDSRequest,
+    s3_endpoint: String,
+) -> Result<(), MigrationError> {
+    match export_repo_to_s3(req, &s3_endpoint).await {
+        Ok(()) => {
+            let mut st = state.write().await;
+            st.record_success(id);
+            Ok(())
+        }
+        Err(error) => {
+            let mut st = state.write().await;
+            st.record_failure(id);
+            Err(error)
+        }
+    }
+}
+
+#[tracing::instrument(skip(req), fields(did = %req.did, pds_host = %req.pds_host))]
+pub async fn export_repo_to_s3(
+    req: ExportPDSRequest,
+    endpoint_url: &str,
+) -> Result<(), MigrationError> {
+    let did = req.did.clone();
+    tracing::info!("[{}] Export repository request received", did);
+    let download_start = Instant::now();
+    pdsmigration_common::export_pds_api(req).await?;
+    tracing::info!(
+        "[{}] Repository download phase finished in {:.1}s, starting S3 upload",
+        did,
+        download_start.elapsed().as_secs_f64()
+    );
+
+    tracing::debug!(
+        "[{}] Loading AWS config with endpoint: {}",
+        did,
+        endpoint_url
+    );
+    let config = aws_config::from_env()
+        .region("auto")
+        .endpoint_url(endpoint_url)
+        .load()
+        .await;
+    let client = aws_sdk_s3::Client::new(&config);
+
+    let bucket_name = "migration".to_string();
+    let file_name = did_to_car_filename(&did);
+    let key = format!("migration/{file_name}");
+    let file_path = repo_car_path(&did).map_err(|e| MigrationError::Runtime {
+        message: e.to_string(),
+    })?;
+
+    tracing::debug!(
+        "[{}] Uploading file {} to S3 bucket {} with key {}",
+        did,
+        file_path.display(),
+        bucket_name,
+        key
+    );
+
+    match tokio::fs::metadata(&file_path).await {
+        Ok(meta) => tracing::info!(
+            "[{}] Exported repository file size: {} bytes",
+            did,
+            meta.len()
+        ),
+        Err(e) => tracing::warn!(
+            "[{}] Failed to read exported repository file metadata: {:?}",
+            did,
+            e
+        ),
+    }
+
+    let upload_start = Instant::now();
+    let body = aws_sdk_s3::primitives::ByteStream::from_path(&file_path)
+        .await
+        .map_err(|e| MigrationError::Runtime {
+            message: e.to_string(),
+        })?;
+
+    client
+        .put_object()
+        .bucket(&bucket_name)
+        .key(&key)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| MigrationError::Runtime {
+            message: e.to_string(),
+        })?;
+
+    tracing::info!(
+        "[{}] Repository exported and uploaded to S3 successfully (upload phase {:.1}s)",
+        did,
+        upload_start.elapsed().as_secs_f64()
+    );
+    Ok(())
+}
+
 /// Upload a single blob, retrying transient failures with exponential backoff.
 async fn upload_blob_with_retries(
     agent: &bsky_sdk::BskyAgent,
@@ -661,6 +799,10 @@ async fn upload_blob_with_retries(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pdsmigration_common::unique_did;
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn test_job_record_new_export_blobs() {
@@ -687,6 +829,14 @@ mod tests {
         let record = JobRecord::new(id, JobKind::UploadBlobs);
 
         assert!(matches!(record.kind, JobKind::UploadBlobs));
+    }
+
+    #[test]
+    fn test_job_record_new_export_repo() {
+        let id = Uuid::new_v4();
+        let record = JobRecord::new(id, JobKind::ExportRepo);
+
+        assert!(matches!(record.kind, JobKind::ExportRepo));
     }
 
     #[test]
@@ -835,6 +985,102 @@ mod tests {
         let got = mgr.get(id).await.unwrap();
         assert_eq!(got.id, id.to_string());
         assert!(matches!(got.kind, JobKind::UploadBlobs));
+    }
+
+    #[actix_rt::test]
+    async fn test_export_repo_to_s3_success() {
+        let pds = MockServer::start().await;
+        let s3 = MockServer::start().await;
+        let did = unique_did("jobexportreposuccess");
+        let payload: &[u8] = b"export-repo-bytes";
+
+        Mock::given(method("GET"))
+            .and(path("/xrpc/com.atproto.server.getSession"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "did": did,
+                "handle": "anothermigration.bsky.social",
+                "active": true
+            })))
+            .mount(&pds)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/xrpc/com.atproto.sync.getRepo"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("ratelimit-remaining", "1000")
+                    .set_body_bytes(payload),
+            )
+            .mount(&pds)
+            .await;
+        Mock::given(method("PUT"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&s3)
+            .await;
+
+        let car_path = repo_car_path(&did).expect("downloads dir resolvable");
+        let _ = std::fs::remove_file(&car_path);
+
+        let result = export_repo_to_s3(
+            ExportPDSRequest {
+                pds_host: pds.uri(),
+                did: did.clone(),
+                token: "origin-jwt".to_string(),
+            },
+            &s3.uri(),
+        )
+        .await;
+
+        assert!(result.is_ok(), "expected export_repo_to_s3 success");
+        let uploaded = s3.received_requests().await.expect("requests recorded");
+        assert!(
+            uploaded.iter().any(|r| r.method.as_str() == "PUT"),
+            "S3 mock should receive an upload PUT request"
+        );
+        let on_disk = std::fs::read(&car_path).expect("export should write CAR file");
+        assert_eq!(on_disk, payload);
+        let _ = std::fs::remove_file(&car_path);
+    }
+
+    #[actix_rt::test]
+    async fn test_export_repo_to_s3_returns_error_when_s3_upload_fails() {
+        let pds = MockServer::start().await;
+        let s3 = MockServer::start().await;
+        let did = unique_did("jobexportrepofail");
+
+        Mock::given(method("GET"))
+            .and(path("/xrpc/com.atproto.server.getSession"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "did": did,
+                "handle": "anothermigration.bsky.social",
+                "active": true
+            })))
+            .mount(&pds)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/xrpc/com.atproto.sync.getRepo"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("ratelimit-remaining", "1000")
+                    .set_body_bytes(b"repo-bytes"),
+            )
+            .mount(&pds)
+            .await;
+        Mock::given(method("PUT"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&s3)
+            .await;
+
+        let result = export_repo_to_s3(
+            ExportPDSRequest {
+                pds_host: pds.uri(),
+                did,
+                token: "origin-jwt".to_string(),
+            },
+            &s3.uri(),
+        )
+        .await;
+
+        assert!(result.is_err(), "expected export_repo_to_s3 failure");
     }
 
     #[test]

--- a/pdsmigration-web/src/background_jobs.rs
+++ b/pdsmigration-web/src/background_jobs.rs
@@ -1078,7 +1078,10 @@ mod tests {
         )
         .await;
 
-        assert!(result.is_ok(), "expected export_repo_to_s3 success: {result:?}");
+        assert!(
+            result.is_ok(),
+            "expected export_repo_to_s3 success: {result:?}"
+        );
         let uploaded = s3.received_requests().await.expect("requests recorded");
         assert!(
             uploaded.iter().any(|r| r.method.as_str() == "PUT"),

--- a/pdsmigration-web/src/background_jobs.rs
+++ b/pdsmigration-web/src/background_jobs.rs
@@ -801,8 +801,55 @@ mod tests {
     use super::*;
     use pdsmigration_common::unique_did;
     use serde_json::json;
+    use std::env;
+    use std::sync::LazyLock;
+    use tokio::sync::{Mutex, MutexGuard};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    struct EnvGuard {
+        _guard: MutexGuard<'static, ()>,
+        previous: Vec<(String, Option<String>)>,
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.previous {
+                match v {
+                    Some(value) => env::set_var(k, value),
+                    None => env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    async fn with_aws_test_env() -> EnvGuard {
+        let guard = ENV_LOCK.lock().await;
+        let vars = [
+            ("AWS_ACCESS_KEY_ID", Some("test-access-key")),
+            ("AWS_SECRET_ACCESS_KEY", Some("test-secret-key")),
+            ("AWS_EC2_METADATA_DISABLED", Some("true")),
+        ];
+
+        let previous = vars
+            .iter()
+            .map(|(k, _)| ((*k).to_string(), env::var(k).ok()))
+            .collect::<Vec<_>>();
+
+        for (k, v) in vars {
+            match v {
+                Some(value) => env::set_var(k, value),
+                None => env::remove_var(k),
+            }
+        }
+
+        EnvGuard {
+            _guard: guard,
+            previous,
+        }
+    }
 
     #[test]
     fn test_job_record_new_export_blobs() {
@@ -989,6 +1036,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_export_repo_to_s3_success() {
+        let _env_guard = with_aws_test_env().await;
         let pds = MockServer::start().await;
         let s3 = MockServer::start().await;
         let did = unique_did("jobexportreposuccess");
@@ -1030,7 +1078,7 @@ mod tests {
         )
         .await;
 
-        assert!(result.is_ok(), "expected export_repo_to_s3 success");
+        assert!(result.is_ok(), "expected export_repo_to_s3 success: {result:?}");
         let uploaded = s3.received_requests().await.expect("requests recorded");
         assert!(
             uploaded.iter().any(|r| r.method.as_str() == "PUT"),
@@ -1043,6 +1091,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_export_repo_to_s3_returns_error_when_s3_upload_fails() {
+        let _env_guard = with_aws_test_env().await;
         let pds = MockServer::start().await;
         let s3 = MockServer::start().await;
         let did = unique_did("jobexportrepofail");

--- a/pdsmigration-web/src/main.rs
+++ b/pdsmigration-web/src/main.rs
@@ -7,8 +7,9 @@ mod openapi;
 
 use crate::api::{
     activate_account_api, create_account_api, deactivate_account_api, enqueue_export_blobs_job_api,
-    enqueue_upload_blobs_job_api, export_pds_api, get_job_api, get_service_auth_api, health_check,
-    import_pds_api, migrate_plc_api, migrate_preferences_api, request_token_api,
+    enqueue_export_repo_job_api, enqueue_upload_blobs_job_api, export_pds_api, get_job_api,
+    get_service_auth_api, health_check, import_pds_api, migrate_plc_api, migrate_preferences_api,
+    request_token_api,
 };
 use crate::background_jobs::JobManager;
 use crate::config::AppConfig;
@@ -64,6 +65,7 @@ fn init_http_server(app_config: AppConfig) -> io::Result<Server> {
             .service(export_pds_api)
             .service(import_pds_api)
             .service(enqueue_export_blobs_job_api)
+            .service(enqueue_export_repo_job_api)
             .service(enqueue_upload_blobs_job_api)
             .service(get_job_api)
             .service(activate_account_api)

--- a/pdsmigration-web/src/openapi.rs
+++ b/pdsmigration-web/src/openapi.rs
@@ -18,6 +18,7 @@ use crate::api::*;
         migrate_plc_api,
         get_service_auth_api,
         enqueue_export_blobs_job_api,
+        enqueue_export_repo_job_api,
         enqueue_upload_blobs_job_api,
         get_job_api,
     ),

--- a/pdsmigration-web/tests/export_repo_job_http_lifecycle.rs
+++ b/pdsmigration-web/tests/export_repo_job_http_lifecycle.rs
@@ -5,15 +5,63 @@ use pdsmigration_web::{
     background_jobs::JobManager,
 };
 use serde_json::json;
+use std::env;
+use std::sync::LazyLock;
 use std::time::Duration;
+use tokio::sync::{Mutex, MutexGuard};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 mod common;
 use common::{create_test_config, session_body, unique_did};
 
+static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+struct EnvGuard {
+    _guard: MutexGuard<'static, ()>,
+    previous: Vec<(String, Option<String>)>,
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (k, v) in &self.previous {
+            match v {
+                Some(value) => env::set_var(k, value),
+                None => env::remove_var(k),
+            }
+        }
+    }
+}
+
+async fn with_aws_test_env() -> EnvGuard {
+    let guard = ENV_LOCK.lock().await;
+    let vars = [
+        ("AWS_ACCESS_KEY_ID", Some("test-access-key")),
+        ("AWS_SECRET_ACCESS_KEY", Some("test-secret-key")),
+        ("AWS_EC2_METADATA_DISABLED", Some("true")),
+    ];
+
+    let previous = vars
+        .iter()
+        .map(|(k, _)| ((*k).to_string(), env::var(k).ok()))
+        .collect::<Vec<_>>();
+
+    for (k, v) in vars {
+        match v {
+            Some(value) => env::set_var(k, value),
+            None => env::remove_var(k),
+        }
+    }
+
+    EnvGuard {
+        _guard: guard,
+        previous,
+    }
+}
+
 #[actix_rt::test]
 async fn export_repo_job_reaches_success_through_http_api() {
+    let _env_guard = with_aws_test_env().await;
     let pds = MockServer::start().await;
     let s3 = MockServer::start().await;
     let did = unique_did("webexportrepojob");

--- a/pdsmigration-web/tests/export_repo_job_http_lifecycle.rs
+++ b/pdsmigration-web/tests/export_repo_job_http_lifecycle.rs
@@ -1,0 +1,100 @@
+use actix_web::{http::StatusCode, test, web, App};
+use pdsmigration_common::repo_car_path;
+use pdsmigration_web::{
+    api::{enqueue_export_repo_job_api, get_job_api},
+    background_jobs::JobManager,
+};
+use serde_json::json;
+use std::time::Duration;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+mod common;
+use common::{create_test_config, session_body, unique_did};
+
+#[actix_rt::test]
+async fn export_repo_job_reaches_success_through_http_api() {
+    let pds = MockServer::start().await;
+    let s3 = MockServer::start().await;
+    let did = unique_did("webexportrepojob");
+    let payload: &[u8] = b"fake-car-bytes-from-get-repo";
+
+    Mock::given(method("GET"))
+        .and(path("/xrpc/com.atproto.server.getSession"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_body(&did)))
+        .mount(&pds)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/xrpc/com.atproto.sync.getRepo"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("ratelimit-remaining", "1000")
+                .set_body_bytes(payload),
+        )
+        .mount(&pds)
+        .await;
+    Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&s3)
+        .await;
+
+    let car_path = repo_car_path(&did).expect("downloads dir resolvable");
+    let _ = std::fs::remove_file(&car_path);
+
+    let mut config = create_test_config();
+    config.external_services.s3_endpoint = s3.uri();
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(config))
+            .app_data(web::Data::new(JobManager::new()))
+            .service(enqueue_export_repo_job_api)
+            .service(get_job_api),
+    )
+    .await;
+
+    let enqueue = test::TestRequest::post()
+        .uri("/jobs/export-repo")
+        .set_json(json!({
+            "pds_host": pds.uri(),
+            "did": did,
+            "token": "origin-jwt",
+        }))
+        .to_request();
+    let enqueue_resp = test::call_service(&app, enqueue).await;
+    assert_eq!(enqueue_resp.status(), StatusCode::ACCEPTED);
+    let body = test::read_body(enqueue_resp).await;
+    let enqueued: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let job_id = enqueued["job_id"].as_str().expect("job_id in 202 body");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let job = loop {
+        let get = test::TestRequest::get()
+            .uri(&format!("/jobs/{job_id}"))
+            .to_request();
+        let get_resp = test::call_service(&app, get).await;
+        assert_eq!(get_resp.status(), StatusCode::OK);
+        let job_body = test::read_body(get_resp).await;
+        let job: serde_json::Value = serde_json::from_slice(&job_body).unwrap();
+        match job["status"].as_str().unwrap() {
+            "success" | "error" => break job,
+            _ => {}
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("job did not finish in time; last={job:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    };
+
+    assert_eq!(
+        job["status"].as_str().unwrap(),
+        "success",
+        "export-repo job should succeed against mocked services; got {job:?}"
+    );
+    assert_eq!(job["id"].as_str().unwrap(), job_id);
+    let progress = &job["progress"];
+    assert_eq!(progress["successful_blobs"].as_u64(), Some(1));
+    assert_eq!(progress["invalid_blobs"].as_u64(), Some(0));
+    assert_eq!(progress["total"].as_u64(), Some(1));
+
+    let _ = std::fs::remove_file(&car_path);
+}

--- a/pdsmigration-web/tests/export_repo_sync_api.rs
+++ b/pdsmigration-web/tests/export_repo_sync_api.rs
@@ -13,20 +13,54 @@ use common::{session_body, unique_did};
 
 static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
-async fn set_endpoint_env(value: Option<&str>) -> (MutexGuard<'static, ()>, Option<String>) {
+struct EnvSnapshot {
+    endpoint: Option<String>,
+    aws_access_key_id: Option<String>,
+    aws_secret_access_key: Option<String>,
+    aws_ec2_metadata_disabled: Option<String>,
+}
+
+async fn set_endpoint_env(value: Option<&str>) -> (MutexGuard<'static, ()>, EnvSnapshot) {
     let guard = ENV_LOCK.lock().await;
-    let previous = env::var("ENDPOINT").ok();
+    let previous = EnvSnapshot {
+        endpoint: env::var("ENDPOINT").ok(),
+        aws_access_key_id: env::var("AWS_ACCESS_KEY_ID").ok(),
+        aws_secret_access_key: env::var("AWS_SECRET_ACCESS_KEY").ok(),
+        aws_ec2_metadata_disabled: env::var("AWS_EC2_METADATA_DISABLED").ok(),
+    };
+
     match value {
         Some(v) => env::set_var("ENDPOINT", v),
         None => env::remove_var("ENDPOINT"),
     }
+
+    // Ensure AWS SDK auth resolution is deterministic in CI and local runs.
+    env::set_var("AWS_ACCESS_KEY_ID", "test-access-key");
+    env::set_var("AWS_SECRET_ACCESS_KEY", "test-secret-key");
+    env::set_var("AWS_EC2_METADATA_DISABLED", "true");
+
     (guard, previous)
 }
 
-fn restore_endpoint_env(previous: Option<String>) {
-    match previous {
+fn restore_endpoint_env(previous: EnvSnapshot) {
+    match previous.endpoint {
         Some(v) => env::set_var("ENDPOINT", v),
         None => env::remove_var("ENDPOINT"),
+    }
+
+    match previous.aws_access_key_id {
+        Some(v) => env::set_var("AWS_ACCESS_KEY_ID", v),
+        None => env::remove_var("AWS_ACCESS_KEY_ID"),
+    }
+
+    match previous.aws_secret_access_key {
+        Some(v) => env::set_var("AWS_SECRET_ACCESS_KEY", v),
+        None => env::remove_var("AWS_SECRET_ACCESS_KEY"),
+    }
+
+    match previous.aws_ec2_metadata_disabled {
+        Some(v) => env::set_var("AWS_EC2_METADATA_DISABLED", v),
+        None => env::remove_var("AWS_EC2_METADATA_DISABLED"),
     }
 }
 

--- a/pdsmigration-web/tests/export_repo_sync_api.rs
+++ b/pdsmigration-web/tests/export_repo_sync_api.rs
@@ -3,17 +3,18 @@ use pdsmigration_common::repo_car_path;
 use pdsmigration_web::api::export_pds_api;
 use serde_json::json;
 use std::env;
-use std::sync::{Mutex, MutexGuard};
+use std::sync::LazyLock;
+use tokio::sync::{Mutex, MutexGuard};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 mod common;
 use common::{session_body, unique_did};
 
-static ENV_LOCK: Mutex<()> = Mutex::new(());
+static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
-fn set_endpoint_env(value: Option<&str>) -> (MutexGuard<'static, ()>, Option<String>) {
-    let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+async fn set_endpoint_env(value: Option<&str>) -> (MutexGuard<'static, ()>, Option<String>) {
+    let guard = ENV_LOCK.lock().await;
     let previous = env::var("ENDPOINT").ok();
     match value {
         Some(v) => env::set_var("ENDPOINT", v),
@@ -59,7 +60,7 @@ async fn export_repo_sync_api_succeeds_with_mocked_pds_and_s3() {
     let _ = std::fs::remove_file(&car_path);
 
     let app = test::init_service(App::new().service(export_pds_api)).await;
-    let (_guard, previous) = set_endpoint_env(Some(&s3.uri()));
+    let (_guard, previous) = set_endpoint_env(Some(&s3.uri())).await;
     let req = test::TestRequest::post()
         .uri("/export-repo")
         .set_json(json!({
@@ -86,7 +87,7 @@ async fn export_repo_sync_api_succeeds_with_mocked_pds_and_s3() {
 async fn export_repo_sync_api_returns_runtime_error_without_endpoint_env() {
     let app = test::init_service(App::new().service(export_pds_api)).await;
 
-    let (_guard, previous) = set_endpoint_env(None);
+    let (_guard, previous) = set_endpoint_env(None).await;
     let req = test::TestRequest::post()
         .uri("/export-repo")
         .set_json(json!({

--- a/pdsmigration-web/tests/export_repo_sync_api.rs
+++ b/pdsmigration-web/tests/export_repo_sync_api.rs
@@ -1,0 +1,104 @@
+use actix_web::{http::StatusCode, test, App};
+use pdsmigration_common::repo_car_path;
+use pdsmigration_web::api::export_pds_api;
+use serde_json::json;
+use std::env;
+use std::sync::{Mutex, MutexGuard};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+mod common;
+use common::{session_body, unique_did};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn set_endpoint_env(value: Option<&str>) -> (MutexGuard<'static, ()>, Option<String>) {
+    let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let previous = env::var("ENDPOINT").ok();
+    match value {
+        Some(v) => env::set_var("ENDPOINT", v),
+        None => env::remove_var("ENDPOINT"),
+    }
+    (guard, previous)
+}
+
+fn restore_endpoint_env(previous: Option<String>) {
+    match previous {
+        Some(v) => env::set_var("ENDPOINT", v),
+        None => env::remove_var("ENDPOINT"),
+    }
+}
+
+#[actix_rt::test]
+async fn export_repo_sync_api_succeeds_with_mocked_pds_and_s3() {
+    let pds = MockServer::start().await;
+    let s3 = MockServer::start().await;
+    let did = unique_did("websyncsuccess");
+    let payload: &[u8] = b"sync-export-repo-payload";
+
+    Mock::given(method("GET"))
+        .and(path("/xrpc/com.atproto.server.getSession"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(session_body(&did)))
+        .mount(&pds)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/xrpc/com.atproto.sync.getRepo"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("ratelimit-remaining", "1000")
+                .set_body_bytes(payload),
+        )
+        .mount(&pds)
+        .await;
+    Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&s3)
+        .await;
+
+    let car_path = repo_car_path(&did).expect("downloads dir resolvable");
+    let _ = std::fs::remove_file(&car_path);
+
+    let app = test::init_service(App::new().service(export_pds_api)).await;
+    let (_guard, previous) = set_endpoint_env(Some(&s3.uri()));
+    let req = test::TestRequest::post()
+        .uri("/export-repo")
+        .set_json(json!({
+            "pds_host": pds.uri(),
+            "did": did,
+            "token": "origin-jwt",
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    restore_endpoint_env(previous);
+
+    let uploaded = s3.received_requests().await.expect("requests recorded");
+    assert!(
+        uploaded.iter().any(|r| r.method.as_str() == "PUT"),
+        "S3 mock should receive an upload PUT request"
+    );
+    let on_disk = std::fs::read(&car_path).expect("export should write CAR file");
+    assert_eq!(on_disk, payload);
+    let _ = std::fs::remove_file(&car_path);
+}
+
+#[actix_rt::test]
+async fn export_repo_sync_api_returns_runtime_error_without_endpoint_env() {
+    let app = test::init_service(App::new().service(export_pds_api)).await;
+
+    let (_guard, previous) = set_endpoint_env(None);
+    let req = test::TestRequest::post()
+        .uri("/export-repo")
+        .set_json(json!({
+            "pds_host": "https://pds.example.com",
+            "did": "did:plc:abc123",
+            "token": "origin-jwt",
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body = test::read_body(resp).await;
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["code"], "Runtime");
+    restore_endpoint_env(previous);
+}

--- a/pdsmigration-web/tests/integration_tests.rs
+++ b/pdsmigration-web/tests/integration_tests.rs
@@ -2,9 +2,9 @@ use actix_web::{http::StatusCode, test, web, App};
 use pdsmigration_web::{
     api::{
         activate_account_api, create_account_api, deactivate_account_api,
-        enqueue_export_blobs_job_api, enqueue_upload_blobs_job_api, export_pds_api, get_job_api,
-        get_service_auth_api, health_check, import_pds_api, migrate_plc_api,
-        migrate_preferences_api, request_token_api,
+        enqueue_export_blobs_job_api, enqueue_export_repo_job_api, enqueue_upload_blobs_job_api,
+        export_pds_api, get_job_api, get_service_auth_api, health_check, import_pds_api,
+        migrate_plc_api, migrate_preferences_api, request_token_api,
     },
     background_jobs::JobManager,
     config::{AppConfig, ExternalServices, ServerConfig},
@@ -74,6 +74,7 @@ mod integration_tests {
                 .service(migrate_plc_api)
                 .service(get_service_auth_api)
                 .service(enqueue_export_blobs_job_api)
+                .service(enqueue_export_repo_job_api)
                 .service(enqueue_upload_blobs_job_api)
                 .service(get_job_api),
         )
@@ -476,6 +477,72 @@ mod integration_tests {
 
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_rt::test]
+    async fn test_enqueue_export_repo_job_missing_fields() {
+        let app_config = create_test_config();
+        let job_manager = web::Data::new(JobManager::new());
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(app_config))
+                .app_data(job_manager)
+                .service(enqueue_export_repo_job_api),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/jobs/export-repo")
+            .set_json(json!({}))
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_rt::test]
+    async fn test_get_existing_export_repo_job() {
+        let app_config = create_test_config();
+        let job_manager = web::Data::new(JobManager::new());
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(app_config))
+                .app_data(job_manager.clone())
+                .service(enqueue_export_repo_job_api)
+                .service(get_job_api),
+        )
+        .await;
+
+        let export_repo_request = json!({
+            "pds_host": "https://origin.pds.host",
+            "did": "did:plc:test123456789",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.example.signature"
+        });
+
+        let req = test::TestRequest::post()
+            .uri("/jobs/export-repo")
+            .set_json(&export_repo_request)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+
+        let body = test::read_body(resp).await;
+        let response: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let job_id = response["job_id"].as_str().unwrap();
+
+        let get_req = test::TestRequest::get()
+            .uri(&format!("/jobs/{}", job_id))
+            .to_request();
+
+        let get_resp = test::call_service(&app, get_req).await;
+        assert_eq!(get_resp.status(), StatusCode::OK);
+
+        let job_body = test::read_body(get_resp).await;
+        let job: serde_json::Value = serde_json::from_slice(&job_body).unwrap();
+        assert_eq!(job["id"].as_str().unwrap(), job_id);
     }
 
     #[actix_rt::test]


### PR DESCRIPTION
## Description

Allowing the client (front-end) to run the export repo step as a background job, instead of a single request-response cycle.

This will mitigate any issues with large repo exports that may time out if attempted on a single request, and reuses the patterns in our export/import blobs.

## Related Issues

<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing

Added unit tests to both the existing and new export repo endpoints.

## Affected Packages

<!-- Mark all packages affected by this change -->

- [x] `pdsmigration-common` - Core library with migration logic
- [ ] `pdsmigration-gui` - Desktop GUI application (egui/eframe)
- [ ] `pdsmigration-web` - Web service (Actix-Web + AWS S3)
- [ ] Project configuration (Cargo.toml, CI/CD, Docker, etc.)

## Type of Change

<!-- Mark relevant options with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements