### PR TITLE
Refactor: remove finished jobs from memory after expiration time

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ cargo test -p pdsmigration-common
 | `SERVER_PORT`              | No       | `9090`                  | HTTP server port                      |
 | `WORKER_COUNT`             | No       | `2`                     | Number of worker threads              |
 | `CONCURRENT_TASKS_PER_JOB` | No       | `3`                     | Max concurrent blob processes per job |
+| `JOB_RETENTION_SECS`       | No       | `3600`                  | How long finished jobs are kept in memory before being pruned |
 
 ### AWS S3 Configuration
 

--- a/pdsmigration-web/src/background_jobs.rs
+++ b/pdsmigration-web/src/background_jobs.rs
@@ -23,6 +23,7 @@ use uuid::Uuid;
 const MAX_BACKOFF_MS: u64 = 10_000;
 const BASE_BACKOFF_MS: u64 = 250;
 const BACKOFF_JITTER_MS: u64 = 250;
+pub const DEFAULT_JOB_RETENTION_SECS: u64 = 3600;
 
 fn backoff_base_ms(attempt: u32) -> u64 {
     let shift = attempt.min(6);
@@ -125,6 +126,7 @@ impl JobRecord {
 #[derive(Clone)]
 pub struct JobManager {
     state: Arc<RwLock<JobState>>,
+    retention: Duration,
 }
 
 #[derive(Default, Debug)]
@@ -133,6 +135,15 @@ struct JobState {
 }
 
 impl JobState {
+    pub fn prune_finished(&mut self, retention: Duration) {
+        let now = now_millis();
+        let retention_ms = retention.as_millis() as u64;
+        self.records.retain(|_, r| match r.finished_at {
+            Some(finished_at) => now.saturating_sub(finished_at) < retention_ms,
+            None => true,
+        });
+    }
+
     pub fn set_running(&mut self, id: Uuid) {
         if let Some(r) = self.records.get_mut(&id) {
             r.status = JobStatus::Running;
@@ -210,9 +221,10 @@ impl JobState {
 }
 
 impl JobManager {
-    pub fn new() -> Self {
+    pub fn new(retention: Duration) -> Self {
         Self {
             state: Arc::new(RwLock::new(JobState::default())),
+            retention,
         }
     }
 
@@ -243,6 +255,7 @@ impl JobManager {
 
         {
             let mut st = self.state.write().await;
+            st.prune_finished(self.retention);
             st.records.insert(id, rec);
         }
 
@@ -275,6 +288,7 @@ impl JobManager {
 
         {
             let mut st = self.state.write().await;
+            st.prune_finished(self.retention);
             st.records.insert(id, rec);
         }
 
@@ -308,6 +322,7 @@ impl JobManager {
 
         {
             let mut st = self.state.write().await;
+            st.prune_finished(self.retention);
             st.records.insert(id, rec);
             st.update_total(id, 1);
         }
@@ -331,7 +346,7 @@ impl JobManager {
 
 impl Default for JobManager {
     fn default() -> Self {
-        Self::new()
+        Self::new(Duration::from_secs(DEFAULT_JOB_RETENTION_SECS))
     }
 }
 
@@ -1013,15 +1028,46 @@ mod tests {
         assert!(state.records.is_empty());
     }
 
+    #[test]
+    fn test_prune_finished_drops_only_expired_jobs() {
+        let mut state = JobState::default();
+
+        // Finished long ago, should be pruned.
+        let old_id = Uuid::new_v4();
+        let mut old = JobRecord::new(old_id, JobKind::UploadBlobs);
+        old.status = JobStatus::Success;
+        old.finished_at = Some(now_millis().saturating_sub(10_000));
+        state.records.insert(old_id, old);
+
+        // Finished just now, should be kept.
+        let recent_id = Uuid::new_v4();
+        let mut recent = JobRecord::new(recent_id, JobKind::UploadBlobs);
+        recent.status = JobStatus::Success;
+        recent.finished_at = Some(now_millis());
+        state.records.insert(recent_id, recent);
+
+        // Still running (no finished_at), should always be kept.
+        let running_id = Uuid::new_v4();
+        state
+            .records
+            .insert(running_id, JobRecord::new(running_id, JobKind::UploadBlobs));
+
+        state.prune_finished(Duration::from_secs(5));
+
+        assert!(!state.records.contains_key(&old_id));
+        assert!(state.records.contains_key(&recent_id));
+        assert!(state.records.contains_key(&running_id));
+    }
+
     #[actix_rt::test]
     async fn test_job_manager_get_returns_none_when_unknown() {
-        let mgr = JobManager::new();
+        let mgr = JobManager::new(Duration::from_secs(DEFAULT_JOB_RETENTION_SECS));
         assert!(mgr.get(Uuid::new_v4()).await.is_none());
     }
 
     #[actix_rt::test]
     async fn test_job_manager_get_after_manual_insert() {
-        let mgr = JobManager::new();
+        let mgr = JobManager::new(Duration::from_secs(DEFAULT_JOB_RETENTION_SECS));
         let id = Uuid::new_v4();
         {
             let mut st = mgr.state.write().await;

--- a/pdsmigration-web/src/background_jobs.rs
+++ b/pdsmigration-web/src/background_jobs.rs
@@ -1051,6 +1051,7 @@ mod tests {
         state
             .records
             .insert(running_id, JobRecord::new(running_id, JobKind::UploadBlobs));
+        state.set_running(running_id);
 
         state.prune_finished(Duration::from_secs(5));
 

--- a/pdsmigration-web/src/config.rs
+++ b/pdsmigration-web/src/config.rs
@@ -15,6 +15,7 @@ pub struct ServerConfig {
     pub upload_max_attempts: u32,
     pub rate_limit_window_secs: u64,
     pub rate_limit_max_requests: u64,
+    pub job_retention_secs: u64,
     pub auth_token: Option<String>,
 }
 
@@ -34,6 +35,7 @@ impl AppConfig {
         let rate_limit_window_secs = env::var("RATE_LIMIT_WINDOW_SECS").unwrap_or("60".to_string());
         let rate_limit_max_requests =
             env::var("RATE_LIMIT_MAX_REQUESTS").unwrap_or("240".to_string());
+        let job_retention_secs = env::var("JOB_RETENTION_SECS").unwrap_or("3600".to_string());
 
         Self {
             server: ServerConfig {
@@ -43,6 +45,7 @@ impl AppConfig {
                 upload_max_attempts: upload_max_attempts.parse().unwrap(),
                 rate_limit_window_secs: rate_limit_window_secs.parse().unwrap(),
                 rate_limit_max_requests: rate_limit_max_requests.parse().unwrap(),
+                job_retention_secs: job_retention_secs.parse().unwrap(),
                 auth_token: env::var("AUTH_TOKEN").ok(),
             },
             external_services: ExternalServices { s3_endpoint },
@@ -94,6 +97,7 @@ mod tests {
                 ("UPLOAD_MAX_ATTEMPTS", None),
                 ("RATE_LIMIT_WINDOW_SECS", None),
                 ("RATE_LIMIT_MAX_REQUESTS", None),
+                ("JOB_RETENTION_SECS", None),
                 ("AUTH_TOKEN", None),
                 ("ENDPOINT", Some("https://s3.example.com")),
             ],
@@ -105,6 +109,7 @@ mod tests {
                 assert_eq!(cfg.server.upload_max_attempts, 3);
                 assert_eq!(cfg.server.rate_limit_window_secs, 60);
                 assert_eq!(cfg.server.rate_limit_max_requests, 240);
+                assert_eq!(cfg.server.job_retention_secs, 3600);
                 assert!(cfg.server.auth_token.is_none());
                 assert_eq!(cfg.external_services.s3_endpoint, "https://s3.example.com");
             },
@@ -121,6 +126,7 @@ mod tests {
                 ("UPLOAD_MAX_ATTEMPTS", Some("7")),
                 ("RATE_LIMIT_WINDOW_SECS", Some("30")),
                 ("RATE_LIMIT_MAX_REQUESTS", Some("100")),
+                ("JOB_RETENTION_SECS", Some("120")),
                 ("AUTH_TOKEN", Some("secret-token")),
                 ("ENDPOINT", Some("https://custom.example.com")),
             ],
@@ -132,6 +138,7 @@ mod tests {
                 assert_eq!(cfg.server.upload_max_attempts, 7);
                 assert_eq!(cfg.server.rate_limit_window_secs, 30);
                 assert_eq!(cfg.server.rate_limit_max_requests, 100);
+                assert_eq!(cfg.server.job_retention_secs, 120);
                 assert_eq!(cfg.server.auth_token.as_deref(), Some("secret-token"));
                 assert_eq!(
                     cfg.external_services.s3_endpoint,

--- a/pdsmigration-web/src/main.rs
+++ b/pdsmigration-web/src/main.rs
@@ -37,7 +37,7 @@ use utoipa_swagger_ui::SwaggerUi;
 fn init_http_server(app_config: AppConfig) -> io::Result<Server> {
     let server_port = app_config.server.port;
     let worker_count = app_config.server.workers;
-    let job_manager = JobManager::new();
+    let job_manager = JobManager::new(Duration::from_secs(app_config.server.job_retention_secs));
     let prometheus = PrometheusMetricsBuilder::new("api")
         .endpoint("/metrics")
         .build()
@@ -133,6 +133,7 @@ mod tests {
                 upload_max_attempts: 4,
                 rate_limit_window_secs: 60,
                 rate_limit_max_requests: 60,
+                job_retention_secs: 3600,
                 auth_token: None,
             },
             external_services: ExternalServices {
@@ -155,6 +156,7 @@ mod tests {
                 upload_max_attempts: 4,
                 rate_limit_window_secs: 60,
                 rate_limit_max_requests: 60,
+                job_retention_secs: 3600,
                 auth_token: None,
             },
             external_services: ExternalServices {

--- a/pdsmigration-web/src/middleware/auth_token.rs
+++ b/pdsmigration-web/src/middleware/auth_token.rs
@@ -125,6 +125,7 @@ mod tests {
                 upload_max_attempts: 4,
                 rate_limit_window_secs: 60,
                 rate_limit_max_requests: 60,
+                job_retention_secs: 3600,
                 auth_token: token.map(|t| t.to_string()),
             },
             external_services: ExternalServices {

--- a/pdsmigration-web/tests/blob_jobs_deactivated_origin.rs
+++ b/pdsmigration-web/tests/blob_jobs_deactivated_origin.rs
@@ -1,6 +1,7 @@
 use pdsmigration_common::{did_blobs_path, ExportBlobsRequest};
-use pdsmigration_web::background_jobs::{JobManager, JobStatus};
+use pdsmigration_web::background_jobs::{JobManager, JobStatus, DEFAULT_JOB_RETENTION_SECS};
 use serde_json::json;
+use std::time::Duration;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -76,7 +77,7 @@ async fn export_blobs_job_reactivates_deactivated_origin() {
     let blob_dir = did_blobs_path(&did).expect("downloads dir resolvable");
     let _ = std::fs::remove_dir_all(&blob_dir);
 
-    let jobs = JobManager::new();
+    let jobs = JobManager::new(Duration::from_secs(DEFAULT_JOB_RETENTION_SECS));
     let export_id = jobs
         .spawn_export_blobs(ExportBlobsRequest {
             destination: destination.uri(),
@@ -179,7 +180,7 @@ async fn export_blobs_job_leaves_active_origin_untouched() {
     let blob_dir = did_blobs_path(&did).expect("downloads dir resolvable");
     let _ = std::fs::remove_dir_all(&blob_dir);
 
-    let jobs = JobManager::new();
+    let jobs = JobManager::new(Duration::from_secs(DEFAULT_JOB_RETENTION_SECS));
     let export_id = jobs
         .spawn_export_blobs(ExportBlobsRequest {
             destination: destination.uri(),
@@ -269,7 +270,7 @@ async fn export_blobs_job_skips_activation_check_on_regular_flow() {
     let blob_dir = did_blobs_path(&did).expect("downloads dir resolvable");
     let _ = std::fs::remove_dir_all(&blob_dir);
 
-    let jobs = JobManager::new();
+    let jobs = JobManager::new(Duration::from_secs(DEFAULT_JOB_RETENTION_SECS));
     let export_id = jobs
         .spawn_export_blobs(ExportBlobsRequest {
             destination: destination.uri(),

--- a/pdsmigration-web/tests/blob_jobs_failures.rs
+++ b/pdsmigration-web/tests/blob_jobs_failures.rs
@@ -1,6 +1,7 @@
 use pdsmigration_common::{did_blobs_path, ExportBlobsRequest, UploadBlobsRequest};
-use pdsmigration_web::background_jobs::{JobManager, JobStatus};
+use pdsmigration_web::background_jobs::{JobManager, JobStatus, DEFAULT_JOB_RETENTION_SECS};
 use serde_json::json;
+use std::time::Duration;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -45,7 +46,7 @@ async fn export_job_records_failed_blob_but_still_succeeds() {
     let blob_dir = did_blobs_path(&did).expect("downloads dir resolvable");
     let _ = std::fs::remove_dir_all(&blob_dir);
 
-    let jobs = JobManager::new();
+    let jobs = JobManager::new(Duration::from_secs(DEFAULT_JOB_RETENTION_SECS));
     let export_id = jobs
         .spawn_export_blobs(ExportBlobsRequest {
             destination: destination.uri(),
@@ -108,7 +109,7 @@ async fn upload_job_retries_once_and_succeeds() {
     std::fs::create_dir_all(&blob_dir).expect("create blob dir");
     std::fs::write(blob_dir.join("blob-one"), b"retry-me").expect("seed blob");
 
-    let jobs = JobManager::new();
+    let jobs = JobManager::new(Duration::from_secs(DEFAULT_JOB_RETENTION_SECS));
     let upload_id = jobs
         .spawn_upload_blobs(
             UploadBlobsRequest {
@@ -174,7 +175,7 @@ async fn upload_job_records_invalid_when_both_attempts_fail() {
     std::fs::create_dir_all(&blob_dir).expect("create blob dir");
     std::fs::write(blob_dir.join("blob-bad"), b"no good").expect("seed blob");
 
-    let jobs = JobManager::new();
+    let jobs = JobManager::new(Duration::from_secs(DEFAULT_JOB_RETENTION_SECS));
     let upload_id = jobs
         .spawn_upload_blobs(
             UploadBlobsRequest {
@@ -245,7 +246,7 @@ async fn upload_job_first_pass_exhausts_retries_then_second_pass_succeeds() {
     std::fs::create_dir_all(&blob_dir).expect("create blob dir");
     std::fs::write(blob_dir.join("blob-eventual"), b"second-pass-recovers").expect("seed blob");
 
-    let jobs = JobManager::new();
+    let jobs = JobManager::new(Duration::from_secs(DEFAULT_JOB_RETENTION_SECS));
     let upload_id = jobs
         .spawn_upload_blobs(
             UploadBlobsRequest {
@@ -312,7 +313,7 @@ async fn upload_job_marks_invalid_when_first_pass_retries_and_second_pass_all_fa
     std::fs::create_dir_all(&blob_dir).expect("create blob dir");
     std::fs::write(blob_dir.join("blob-doomed"), b"never works").expect("seed blob");
 
-    let jobs = JobManager::new();
+    let jobs = JobManager::new(Duration::from_secs(DEFAULT_JOB_RETENTION_SECS));
     let upload_id = jobs
         .spawn_upload_blobs(
             UploadBlobsRequest {

--- a/pdsmigration-web/tests/blob_jobs_roundtrip.rs
+++ b/pdsmigration-web/tests/blob_jobs_roundtrip.rs
@@ -1,6 +1,7 @@
 use pdsmigration_common::{did_blobs_path, ExportBlobsRequest, UploadBlobsRequest};
-use pdsmigration_web::background_jobs::{JobManager, JobStatus};
+use pdsmigration_web::background_jobs::{JobManager, JobStatus, DEFAULT_JOB_RETENTION_SECS};
 use serde_json::json;
+use std::time::Duration;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -63,7 +64,7 @@ async fn job_manager_blob_roundtrip() {
     let blob_dir = did_blobs_path(&did).expect("downloads dir resolvable");
     let _ = std::fs::remove_dir_all(&blob_dir);
 
-    let jobs = JobManager::new();
+    let jobs = JobManager::new(Duration::from_secs(DEFAULT_JOB_RETENTION_SECS));
 
     // Run the export job through the JobManager.
     let export_id = jobs

--- a/pdsmigration-web/tests/blob_upload_timeout.rs
+++ b/pdsmigration-web/tests/blob_upload_timeout.rs
@@ -1,5 +1,5 @@
 use pdsmigration_common::{did_blobs_path, UploadBlobsRequest};
-use pdsmigration_web::background_jobs::{JobManager, JobStatus};
+use pdsmigration_web::background_jobs::{JobManager, JobStatus, DEFAULT_JOB_RETENTION_SECS};
 use std::time::Duration;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -43,7 +43,7 @@ async fn upload_job_retries_after_request_timeout() {
     std::fs::create_dir_all(&blob_dir).expect("create blob dir");
     std::fs::write(blob_dir.join("blob-slow"), b"slow-then-fast").expect("seed blob");
 
-    let jobs = JobManager::new();
+    let jobs = JobManager::new(Duration::from_secs(DEFAULT_JOB_RETENTION_SECS));
     let upload_id = jobs
         .spawn_upload_blobs(
             UploadBlobsRequest {

--- a/pdsmigration-web/tests/common/mod.rs
+++ b/pdsmigration-web/tests/common/mod.rs
@@ -20,6 +20,7 @@ pub fn create_test_config() -> AppConfig {
             upload_max_attempts: 4,
             rate_limit_window_secs: 60,
             rate_limit_max_requests: 60,
+            job_retention_secs: 3600,
             auth_token: None,
         },
         external_services: ExternalServices {

--- a/pdsmigration-web/tests/export_repo_job_http_lifecycle.rs
+++ b/pdsmigration-web/tests/export_repo_job_http_lifecycle.rs
@@ -2,7 +2,7 @@ use actix_web::{http::StatusCode, test, web, App};
 use pdsmigration_common::repo_car_path;
 use pdsmigration_web::{
     api::{enqueue_export_repo_job_api, get_job_api},
-    background_jobs::JobManager,
+    background_jobs::{JobManager, DEFAULT_JOB_RETENTION_SECS},
 };
 use serde_json::json;
 use std::env;
@@ -94,7 +94,9 @@ async fn export_repo_job_reaches_success_through_http_api() {
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(config))
-            .app_data(web::Data::new(JobManager::new()))
+            .app_data(web::Data::new(JobManager::new(Duration::from_secs(
+                DEFAULT_JOB_RETENTION_SECS,
+            ))))
             .service(enqueue_export_repo_job_api)
             .service(get_job_api),
     )

--- a/pdsmigration-web/tests/integration_tests.rs
+++ b/pdsmigration-web/tests/integration_tests.rs
@@ -6,11 +6,12 @@ use pdsmigration_web::{
         export_pds_api, get_job_api, get_service_auth_api, health_check, import_pds_api,
         migrate_plc_api, migrate_preferences_api, request_token_api,
     },
-    background_jobs::JobManager,
+    background_jobs::{JobManager, DEFAULT_JOB_RETENTION_SECS},
     config::{AppConfig, ExternalServices, ServerConfig},
     APPLICATION_JSON,
 };
 use serde_json::json;
+use std::time::Duration;
 
 #[cfg(test)]
 mod integration_tests {
@@ -25,6 +26,7 @@ mod integration_tests {
                 upload_max_attempts: 4,
                 rate_limit_window_secs: 60,
                 rate_limit_max_requests: 60,
+                job_retention_secs: 3600,
                 auth_token: None,
             },
             external_services: ExternalServices {
@@ -56,7 +58,9 @@ mod integration_tests {
     #[actix_rt::test]
     async fn test_all_routes_configured() {
         let app_config = create_test_config();
-        let job_manager = web::Data::new(JobManager::new());
+        let job_manager = web::Data::new(JobManager::new(Duration::from_secs(
+            DEFAULT_JOB_RETENTION_SECS,
+        )));
 
         // Test that we can create an app with all routes without errors
         let _app = test::init_service(
@@ -349,7 +353,9 @@ mod integration_tests {
     #[actix_rt::test]
     async fn test_enqueue_export_blobs_job_missing_fields() {
         let app_config = create_test_config();
-        let job_manager = web::Data::new(JobManager::new());
+        let job_manager = web::Data::new(JobManager::new(Duration::from_secs(
+            DEFAULT_JOB_RETENTION_SECS,
+        )));
 
         let app = test::init_service(
             App::new()
@@ -371,7 +377,9 @@ mod integration_tests {
     #[actix_rt::test]
     async fn test_get_nonexistent_job() {
         let app_config = create_test_config();
-        let job_manager = web::Data::new(JobManager::new());
+        let job_manager = web::Data::new(JobManager::new(Duration::from_secs(
+            DEFAULT_JOB_RETENTION_SECS,
+        )));
 
         let app = test::init_service(
             App::new()
@@ -392,7 +400,9 @@ mod integration_tests {
     #[actix_rt::test]
     async fn test_get_job_with_invalid_uuid_format() {
         let app_config = create_test_config();
-        let job_manager = web::Data::new(JobManager::new());
+        let job_manager = web::Data::new(JobManager::new(Duration::from_secs(
+            DEFAULT_JOB_RETENTION_SECS,
+        )));
 
         let app = test::init_service(
             App::new()
@@ -413,7 +423,9 @@ mod integration_tests {
     #[actix_rt::test]
     async fn test_get_existing_job() {
         let app_config = create_test_config();
-        let job_manager = web::Data::new(JobManager::new());
+        let job_manager = web::Data::new(JobManager::new(Duration::from_secs(
+            DEFAULT_JOB_RETENTION_SECS,
+        )));
 
         let app = test::init_service(
             App::new()
@@ -460,7 +472,9 @@ mod integration_tests {
     #[actix_rt::test]
     async fn test_enqueue_upload_blobs_job_missing_fields() {
         let app_config = create_test_config();
-        let job_manager = web::Data::new(JobManager::new());
+        let job_manager = web::Data::new(JobManager::new(Duration::from_secs(
+            DEFAULT_JOB_RETENTION_SECS,
+        )));
 
         let app = test::init_service(
             App::new()
@@ -482,7 +496,9 @@ mod integration_tests {
     #[actix_rt::test]
     async fn test_enqueue_export_repo_job_missing_fields() {
         let app_config = create_test_config();
-        let job_manager = web::Data::new(JobManager::new());
+        let job_manager = web::Data::new(JobManager::new(Duration::from_secs(
+            DEFAULT_JOB_RETENTION_SECS,
+        )));
 
         let app = test::init_service(
             App::new()
@@ -504,7 +520,9 @@ mod integration_tests {
     #[actix_rt::test]
     async fn test_get_existing_export_repo_job() {
         let app_config = create_test_config();
-        let job_manager = web::Data::new(JobManager::new());
+        let job_manager = web::Data::new(JobManager::new(Duration::from_secs(
+            DEFAULT_JOB_RETENTION_SECS,
+        )));
 
         let app = test::init_service(
             App::new()
@@ -548,7 +566,9 @@ mod integration_tests {
     #[actix_rt::test]
     async fn test_get_existing_upload_blobs_job() {
         let app_config = create_test_config();
-        let job_manager = web::Data::new(JobManager::new());
+        let job_manager = web::Data::new(JobManager::new(Duration::from_secs(
+            DEFAULT_JOB_RETENTION_SECS,
+        )));
 
         let app = test::init_service(
             App::new()

--- a/pdsmigration-web/tests/job_http_lifecycle.rs
+++ b/pdsmigration-web/tests/job_http_lifecycle.rs
@@ -2,7 +2,7 @@ use actix_web::{http::StatusCode, test, web, App};
 use pdsmigration_common::did_blobs_path;
 use pdsmigration_web::{
     api::{enqueue_export_blobs_job_api, get_job_api},
-    background_jobs::JobManager,
+    background_jobs::{JobManager, DEFAULT_JOB_RETENTION_SECS},
 };
 use serde_json::json;
 use std::time::Duration;
@@ -52,7 +52,9 @@ async fn export_job_reaches_success_through_http_api() {
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(create_test_config()))
-            .app_data(web::Data::new(JobManager::new()))
+            .app_data(web::Data::new(JobManager::new(Duration::from_secs(
+                DEFAULT_JOB_RETENTION_SECS,
+            ))))
             .service(enqueue_export_blobs_job_api)
             .service(get_job_api),
     )


### PR DESCRIPTION
## Description

Finished job metadata is currently kept in memory forever, this PR cleans up the `JobManager` state to remove finished jobs after a certain expiration time (defaults to 1 hour) next time a job finishes.

## Related Issues

<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing

- Added new unit tests covering the changes
- New and existing tests pass

<!-- Describe the tests you ran to verify your changes -->

## Affected Packages

<!-- Mark all packages affected by this change -->

- [ ] `pdsmigration-common` - Core library with migration logic
- [ ] `pdsmigration-gui` - Desktop GUI application (egui/eframe)
- [x] `pdsmigration-web` - Web service (Actix-Web + AWS S3)
- [ ] Project configuration (Cargo.toml, CI/CD, Docker, etc.)

## Type of Change

<!-- Mark relevant options with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [x] Performance improvement
- [x] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable retention for completed background jobs.
  - Completed jobs are retained in memory for one hour by default, then automatically pruned.
  - Running jobs remain available and are not removed during cleanup.
  - Retention can be customized with the `JOB_RETENTION_SECS` web service setting.
  - Helps limit in-memory buildup from completed jobs while preserving active work.

- **Documentation**
  - Documented the new retention setting, including its default value and pruning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->